### PR TITLE
Show landing page when logged out

### DIFF
--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -1,6 +1,5 @@
 class DashboardController < ApplicationController
-  before_action :authenticate_user!
-
   def index
+    redirect_to new_registration_path unless user_signed_in?
   end
 end

--- a/spec/features/user_signs_out_spec.rb
+++ b/spec/features/user_signs_out_spec.rb
@@ -8,6 +8,6 @@ feature "User signs out" do
 
     click_link "Sign out"
 
-    expect(current_path).to eq new_user_session_path
+    expect(current_path).to eq new_registration_path
   end
 end

--- a/spec/features/user_visits_dashboard_spec.rb
+++ b/spec/features/user_visits_dashboard_spec.rb
@@ -1,0 +1,23 @@
+feature "User visits dashboard" do
+  scenario "when signed in" do
+    sign_in_user
+
+    visit dashboard_path
+
+    expect(current_path).to eq dashboard_path
+  end
+
+  scenario "when signed out" do
+    visit dashboard_path
+
+    expect(current_path).to eq new_registration_path
+  end
+
+  def sign_in_user
+    user = create(:user)
+    visit new_user_session_path
+    fill_in "user_email", with: user.email
+    fill_in "user_password", with: user.password
+    click_button "Sign in"
+  end
+end


### PR DESCRIPTION
When a shiny new potential customer visits trailmix.life we want them to see our landing page and have the opportunity to sign up. Right now, we just show them an auth error:

![screen shot 2014-09-24 at 5 55 57 pm](https://cloud.githubusercontent.com/assets/65323/4397663/885ebebc-4446-11e4-8528-e1f18f3165c6.png)

Instead let's let them be impressed by the beautifully well crafted landing page:

![screen shot 2014-09-24 at 5 56 07 pm](https://cloud.githubusercontent.com/assets/65323/4397665/89c5f11c-4446-11e4-9032-a0b48a355428.png)
