### PR TITLE
Don't integration test signup

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -48,11 +48,11 @@ group :development, :test do
 end
 
 group :test do
+  gem "capybara-webkit"
   gem "database_cleaner"
   gem "fake_stripe"
   gem "formulaic"
   gem "launchy"
-  gem "selenium-webdriver"
   gem "shoulda-matchers", require: false
   gem "timecop"
   gem "webmock"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -61,10 +61,11 @@ GEM
       rack (>= 1.0.0)
       rack-test (>= 0.5.4)
       xpath (~> 2.0)
+    capybara-webkit (1.3.0)
+      capybara (>= 2.0.2, < 2.5.0)
+      json
     celluloid (0.15.2)
       timers (~> 1.1.0)
-    childprocess (0.5.3)
-      ffi (~> 1.0, >= 1.0.11)
     coderay (1.1.0)
     coffee-rails (4.0.1)
       coffee-script (>= 2.2.0)
@@ -108,7 +109,6 @@ GEM
       capybara
       sinatra
       webmock
-    ffi (1.9.3)
     flutie (2.0.0)
     formulaic (0.1.1)
       activesupport
@@ -221,7 +221,6 @@ GEM
       rspec-mocks (~> 3.0.0)
       rspec-support (~> 3.0.0)
     rspec-support (3.0.4)
-    rubyzip (1.1.6)
     safe_yaml (1.0.3)
     sass (3.2.19)
     sass-rails (4.0.3)
@@ -229,11 +228,6 @@ GEM
       sass (~> 3.2.0)
       sprockets (~> 2.8, <= 2.11.0)
       sprockets-rails (~> 2.0)
-    selenium-webdriver (2.43.0)
-      childprocess (~> 0.5)
-      multi_json (~> 1.0)
-      rubyzip (~> 1.0)
-      websocket (~> 1.0)
     shoulda-matchers (2.7.0)
       activesupport (>= 3.0.0)
     sidekiq (3.2.5)
@@ -292,7 +286,6 @@ GEM
     webmock (1.18.0)
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
-    websocket (1.2.1)
     xpath (2.0.0)
       nokogiri (~> 1.3)
 
@@ -306,6 +299,7 @@ DEPENDENCIES
   bootstrap-sass (~> 3.2.0)
   bourbon (~> 3.2.1)
   byebug
+  capybara-webkit
   coffee-rails
   database_cleaner
   devise
@@ -335,7 +329,6 @@ DEPENDENCIES
   redis
   rspec-rails (~> 3.0.0)
   sass-rails (~> 4.0.3)
-  selenium-webdriver
   shoulda-matchers
   sidekiq
   simple_form

--- a/spec/controllers/subscriptions_controller_spec.rb
+++ b/spec/controllers/subscriptions_controller_spec.rb
@@ -1,0 +1,68 @@
+require "rails_helper"
+
+describe SubscriptionsController do
+  describe "#create" do
+    before do
+      stub_sign_in
+    end
+
+    context "with valid params" do
+      it "creates a user, stripe customer, and email" do
+        post :create, default_params
+
+        expect(User.count).to eq(1)
+        expect(FakeStripe.customer_count).to eq(1)
+        expect(ActionMailer::Base.deliveries).not_to be_empty
+      end
+    end
+
+    context "when the user is invalid" do
+      it "does not create a new user or stripe customer" do
+        stub_invalid_user
+
+        post :create, default_params
+
+        expect(User.count).to eq(0)
+        expect(FakeStripe.customer_count).to eq(0)
+      end
+    end
+
+    context "when the credit card fails to charge" do
+      it "does not create a user or stripe customer" do
+        stub_stripe_charge_failure
+
+        post :create, default_params
+
+        expect(User.count).to eq(0)
+        expect(FakeStripe.customer_count).to eq(0)
+        expect(ActionMailer::Base.deliveries).to be_empty
+      end
+    end
+
+    def default_params
+      {
+        email: 'foo@bar.com',
+        password: 'password',
+        stripe_card_id: 'abc123'
+      }
+    end
+
+    def stub_stripe_charge_failure
+      error = Stripe::CardError.new(double, double, double)
+      allow(error).to(receive(:message).and_return("Failed to charge card"))
+
+      allow(Stripe::Customer).to(receive(:create).and_raise(error))
+    end
+
+    def stub_sign_in
+      allow(controller).to receive(:sign_in)
+    end
+
+    def stub_invalid_user
+      user = double("user",
+                    valid?: false,
+                    errors: double('errors').as_null_object)
+      allow(User).to(receive(:new).and_return(user))
+    end
+  end
+end

--- a/spec/features/user_signs_up_spec.rb
+++ b/spec/features/user_signs_up_spec.rb
@@ -1,42 +1,5 @@
 feature "User signs up", js: true do
-  Capybara.default_wait_time = 6
-
-  VALID_CARD_NUMBER = "4242424242424242"
-
-  scenario "using valid data" do
-    fill_in_signup_form
-    fill_in_stripe_checkout(card_number: VALID_CARD_NUMBER)
-
-    expect_to_be_on_dashboard
-    expect(User.count).to eq(1)
-    expect(FakeStripe.customer_count).to eq(1)
-    expect(ActionMailer::Base.deliveries).not_to be_empty
-  end
-
-  scenario "using a duplicate email address" do
-    existing_user = create(:user, email: "user@example.com")
-
-    fill_in_signup_form("user@example.com")
-    fill_in_stripe_checkout(card_number: VALID_CARD_NUMBER)
-
-    expect(page).to have_content("Email has already been taken")
-    expect(FakeStripe.customer_count).to eq(0)
-    expect(ActionMailer::Base.deliveries).to be_empty
-  end
-
-  scenario "with a credit card that fails to charge" do
-    stub_stripe_charge_failure
-
-    fill_in_signup_form
-    fill_in_stripe_checkout(card_number: VALID_CARD_NUMBER)
-
-    expect(page).to have_content("Failed to charge card")
-    expect(User.count).to eq(0)
-    expect(FakeStripe.customer_count).to eq(0)
-    expect(ActionMailer::Base.deliveries).to be_empty
-  end
-
-  scenario "without providing email or password", js: true do
+  scenario "without providing email or password" do
     visit new_registration_path
 
     fill_in "email", with: ""
@@ -53,37 +16,6 @@ feature "User signs up", js: true do
     fill_in "password", with: "password"
 
     expect_button_to_be_enabled
-  end
-
-  def stub_stripe_charge_failure
-    error = Stripe::CardError.new(double, double, double)
-    allow(error).to(receive(:message).and_return("Failed to charge card"))
-
-    allow(Stripe::Customer).to(receive(:create).and_raise(error))
-  end
-
-  def expect_to_be_on_dashboard
-    expect(page).to have_content("You're on the dashboard!")
-  end
-
-  def fill_in_signup_form(email="very-long-email-lol@example.com")
-    visit new_registration_path
-    fill_in "email", with: email
-    fill_in "password", with: "password"
-    click_button "Sign up"
-  end
-
-  def fill_in_stripe_checkout(values={})
-    within_frame("stripe_checkout_app") do
-      sleep 0.1
-      page.execute_script(%Q{ $('#card_number').val('#{values[:card_number]}'); })
-      sleep 0.1
-      page.execute_script(%Q{ $('#cc-exp').val('01/20'); })
-      sleep 0.1
-      fill_in "cc-csc", with: "123"
-      sleep 0.1
-      click_button "submitButton"
-    end
   end
 
   [true, false].each do |disabled|

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -25,5 +25,7 @@ RSpec.configure do |config|
   config.use_transactional_fixtures = false
 end
 
+Capybara.javascript_driver = :webkit
+
 ActiveRecord::Migration.maintain_test_schema!
 WebMock.disable_net_connect!(allow_localhost: true)


### PR DESCRIPTION
Because:
- the tests were super flappy
- and slow

This commit:
- Stops integration testing signup
- Tests signup via a controller spec
- Switches back to capybara-webkit
