### PR TITLE
Require authentication for importing old entries

### DIFF
--- a/app/controllers/imports_controller.rb
+++ b/app/controllers/imports_controller.rb
@@ -1,4 +1,6 @@
 class ImportsController < ApplicationController
+  before_filter :authenticate_user!
+
   def new
     @import = Import.new
   end

--- a/spec/features/user_imports_ohlife_entries_spec.rb
+++ b/spec/features/user_imports_ohlife_entries_spec.rb
@@ -15,4 +15,10 @@ feature "User imports their OhLife entries" do
     expect(Import.count).to eq(1)
     expect(user.entries.count).to eq(2)
   end
+
+  scenario "when signed out" do
+    visit new_import_path
+
+    expect(current_path).to eq(new_user_session_path)
+  end
 end


### PR DESCRIPTION
We've got some folks that would like to import older entries today, but they no longer see the import link. We can add a link to the FAQ in another PR, but before we do we should make sure we require authentication.
