### PR TITLE
Remove default value for ohlife_export column

### DIFF
--- a/db/migrate/20140927193748_remove_default_ohlife_export.rb
+++ b/db/migrate/20140927193748_remove_default_ohlife_export.rb
@@ -1,0 +1,9 @@
+class RemoveDefaultOhlifeExport < ActiveRecord::Migration
+  def up
+    change_column_default :imports, :ohlife_export, nil
+  end
+
+  def down
+    change_column_default :imports, :ohlife_export, ""
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20140926025305) do
+ActiveRecord::Schema.define(version: 20140927193748) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -25,10 +25,10 @@ ActiveRecord::Schema.define(version: 20140926025305) do
   end
 
   create_table "imports", force: true do |t|
-    t.integer  "user_id",                    null: false
-    t.datetime "created_at",                 null: false
-    t.datetime "updated_at",                 null: false
-    t.string   "ohlife_export", default: "", null: false
+    t.integer  "user_id",       null: false
+    t.datetime "created_at",    null: false
+    t.datetime "updated_at",    null: false
+    t.string   "ohlife_export", null: false
   end
 
   create_table "users", force: true do |t|


### PR DESCRIPTION
We added the default here initially to transition older import records. Now that all records have a value for `ohlife_export`, we can remove the default value.
