### PR TITLE
Only load user ids in prompt task

### DIFF
--- a/lib/tasks/trailmix.rake
+++ b/lib/tasks/trailmix.rake
@@ -1,6 +1,6 @@
 namespace :trailmix do
   desc "Delivers all prompt emails"
   task schedule_all_prompts: :environment do
-    PromptTask.new(User.all, PromptWorker).run
+    PromptTask.new(User.pluck(:id), PromptWorker).run
   end
 end


### PR DESCRIPTION
Remember how we wanted to send each prompt email in a separate background job? We are already doing that :white_check_mark: 

While I was poking around though, I noticed we load every user into memory when queueing up the jobs. All we need are the ids. This will help us when Trailmix has 10 million users. :rocket: 
