### PR TITLE
Add simple separator in prompt email for easier scanning

### DIFF
--- a/app/views/prompt_mailer/prompt.text.erb
+++ b/app/views/prompt_mailer/prompt.text.erb
@@ -3,5 +3,7 @@ How are you doing? Simply reply to this email with your entry.
 <% if @entry %>
 Remember this? <%= (time_ago_in_words(@entry.created_at)).capitalize %> ago you wrote the following:
 
+----------------------
+
 <%= @entry.body %>
 <% end %>


### PR DESCRIPTION
When I get these emails from TrailMix, I wish that it was easier to scan and to find what I wrote last time. I added a really simple divider so I can just look for the content below it for my writing.

This could probably be prettier in an HTML template but I thought this was a simpler thing to try. :grinning:
