### PR TITLE
Update Griddle to 1.1.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -163,7 +163,7 @@ GEM
       activesupport
       capybara
       i18n
-    griddler (1.0.0)
+    griddler (1.1.0)
       htmlentities
       rails (>= 3.2.0)
     griddler-sendgrid (0.0.1)


### PR DESCRIPTION
Fixes a bug when users started a paragraph with "On". See http://git.io/uO3zkA
for details.
