### PR TITLE
Drop support for today@trailmix.life

### DIFF
--- a/app/models/email_processor.rb
+++ b/app/models/email_processor.rb
@@ -10,18 +10,11 @@ class EmailProcessor
   private
 
   def user
-    @user ||= begin
-      User.find_by(reply_token: reply_token) ||
-      User.find_by!(email: from)
-    end
+    @user ||= User.find_by!(reply_token: reply_token)
   end
 
   def reply_token
     @email.to.first[:token].downcase
-  end
-
-  def from
-    @email.from[:email].downcase
   end
 
   def date

--- a/spec/features/user_responds_to_prompt_spec.rb
+++ b/spec/features/user_responds_to_prompt_spec.rb
@@ -9,16 +9,8 @@ feature "User responds to a prompt" do
     expect(user.reload.entries).not_to be_empty
   end
 
-  scenario "and it was sent to today@trailmix.life" do
-    user = create(:user, entries: [])
-
-    simulate_email_from(user, to: "today@trailmix.life")
-
-    expect(user.reload.entries).not_to be_empty
-  end
-
-  def simulate_email_from(user, options = {})
-    post("/email_processor", email_params(user).merge(options))
+  def simulate_email_from(user)
+    post("/email_processor", email_params(user))
   end
 
   def email_params(user)
@@ -26,7 +18,7 @@ feature "User responds to a prompt" do
       headers: "Received: by 127.0.0.1 with SMTP...",
       to: user.reply_email,
       cc: "CC <cc@example.com>",
-      from: user.email,
+      from: "whocares@example.com",
       subject: "hello there",
       text: "this is an email message",
       html: "<p>this is an email message</p>",

--- a/spec/models/email_processor_spec.rb
+++ b/spec/models/email_processor_spec.rb
@@ -1,20 +1,5 @@
 describe EmailProcessor do
   describe "#process" do
-    context "for an old email to today@trailmix.life" do
-      it "creates an entry based on the user's email" do
-        user = create(:user)
-        email = create(
-          :griddler_email,
-          from: { email: user.email },
-          body: "I am great"
-        )
-
-        EmailProcessor.new(email).process
-
-        expect(user.newest_entry.body).to eq("I am great")
-      end
-    end
-
     it "creates an entry based on the email token" do
       user = create(:user)
       email = create(
@@ -44,11 +29,7 @@ describe EmailProcessor do
     context "when a user can't be found" do
       it "raises an exception" do
         user = create(:user)
-        email = create(
-          :griddler_email,
-          from: { email: "nobody@example.com" },
-          to: [{ token: "not-a-token" }]
-        )
+        email = create(:griddler_email, to: [{ token: "not-a-token" }])
 
         expect do
           EmailProcessor.new(email).process


### PR DESCRIPTION
This is PR 4 of 4 for replacing `today@trailmix.life` with unique user emails:
1. #90 - Add reply token to User
2. #91 - Add db constraints to reply token
3. #92 - Start using reply token
4. **Drop support for today@trailmix.life**

:tada:
