### PR TITLE
Drop support for today@trailmix.life

### DIFF
--- a/app/models/email_processor.rb
+++ b/app/models/email_processor.rb
@@ -16,18 +16,11 @@ class EmailProcessor
   end
 
   def user
-    @user ||= begin
-      User.find_by(reply_token: reply_token) ||
-      User.find_by!(email: from)
-    end
+    @user ||= User.find_by!(reply_token: reply_token)
   end
 
   def reply_token
     email.to.first[:token].downcase
-  end
-
-  def from
-    email.from[:email].downcase
   end
 
   def date

--- a/spec/features/user_responds_to_prompt_spec.rb
+++ b/spec/features/user_responds_to_prompt_spec.rb
@@ -20,7 +20,7 @@ feature "User responds to a prompt" do
       headers: "Received: by 127.0.0.1 with SMTP...",
       to: user.reply_email,
       cc: "CC <cc@example.com>",
-      from: user.email,
+      from: "whocares@example.com",
       subject: "hello there",
       text: "this is an email message",
       html: "<p>this is an email message</p>",

--- a/spec/models/email_processor_spec.rb
+++ b/spec/models/email_processor_spec.rb
@@ -1,20 +1,5 @@
 describe EmailProcessor do
   describe "#process" do
-    context "for an old email to today@trailmix.life" do
-      it "creates an entry based on the user's email" do
-        user = create(:user)
-        email = create(
-          :griddler_email,
-          from: { email: user.email },
-          body: "I am great"
-        )
-
-        EmailProcessor.new(email).process
-
-        expect(user.newest_entry.body).to eq("I am great")
-      end
-    end
-
     it "creates an entry based on the email token" do
       user = create(:user)
       email = create(
@@ -75,11 +60,7 @@ describe EmailProcessor do
     context "when a user can't be found" do
       it "raises an exception" do
         user = create(:user)
-        email = create(
-          :griddler_email,
-          from: { email: "nobody@example.com" },
-          to: [{ token: "not-a-token" }]
-        )
+        email = create(:griddler_email, to: [{ token: "not-a-token" }])
 
         expect do
           EmailProcessor.new(email).process


### PR DESCRIPTION
We are now sending/receiving emails using unique reply emails. For the next couple days, we are still processing emails that arrive at `today@trailmix.life` just in case folks reply to older emails in their inbox.

Once we stop getting emails at `today@trailmix.life`, we can merge this PR to stop supporting it.
