### PR TITLE
Add welcome email delimiter to Griddler config

### DIFF
--- a/app/mailers/welcome_mailer.rb
+++ b/app/mailers/welcome_mailer.rb
@@ -1,4 +1,6 @@
 class WelcomeMailer < ActionMailer::Base
+  START_OF_MESSAGE = "Welcome to Trailmix, a private place to write."
+
   def welcome(user)
     mail(
       from: "Trailmix <#{user.reply_email}>",

--- a/app/views/welcome_mailer/welcome.text.erb
+++ b/app/views/welcome_mailer/welcome.text.erb
@@ -1,4 +1,4 @@
-Welcome to Trailmix, a private place to write.
+<%= WelcomeMailer::START_OF_MESSAGE %>
 
 To create your first entry, simply reply to this email. That's it.
 

--- a/config/initializers/griddler.rb
+++ b/config/initializers/griddler.rb
@@ -1,5 +1,8 @@
 Griddler.configure do |config|
   config.processor_class = EmailProcessor
-  config.reply_delimiter = PromptMailer::PROMPT_TEXT
+  config.reply_delimiter = [
+    PromptMailer::PROMPT_TEXT,
+    WelcomeMailer::START_OF_MESSAGE
+  ]
   config.email_service = :sendgrid
 end

--- a/spec/mailers/welcome_mailer_spec.rb
+++ b/spec/mailers/welcome_mailer_spec.rb
@@ -5,7 +5,7 @@ describe WelcomeMailer do
 
       mail = WelcomeMailer.welcome(user)
 
-      expect(mail.body.encoded).to include("Welcome")
+      expect(mail.body.encoded).to include("Welcome to Trailmix")
       expect(mail.subject).to include("Write your first entry")
       expect(mail.from).to eq([user.reply_email])
       expect(mail.to).to eq([user.email])


### PR DESCRIPTION
This should help improve parsing of response to the welcome email.
