### PR TITLE
Use date for previous entry in prompt email

### DIFF
--- a/app/views/prompt_mailer/prompt.text.erb
+++ b/app/views/prompt_mailer/prompt.text.erb
@@ -3,7 +3,7 @@
 Simply reply to this email with your entry.
 
 <% if @entry %>
-Remember this? <%= (time_ago_in_words(@entry.created_at)).capitalize %> ago you wrote the following:
+Remember this? <%= (time_ago_in_words(@entry.date)).capitalize %> ago you wrote the following:
 
 ----------------------
 

--- a/spec/mailers/prompt_mailer_spec.rb
+++ b/spec/mailers/prompt_mailer_spec.rb
@@ -50,7 +50,7 @@ describe PromptMailer do
 
       it "says how long ago the past entry was" do
         user = create(:user)
-        entry = create(:entry, user: user, created_at: 1.year.ago)
+        entry = create(:entry, user: user, date: 1.year.ago)
 
         mail = PromptMailer.prompt(user, entry)
 


### PR DESCRIPTION
We are now using `date` instead of `created_at` to show when an entry was written. We need to use that in the prompt email as well.
