### PR TITLE
Add stripe_id column to User

### DIFF
--- a/db/migrate/20141010010843_add_stripe_id_to_user.rb
+++ b/db/migrate/20141010010843_add_stripe_id_to_user.rb
@@ -1,0 +1,5 @@
+class AddStripeIdToUser < ActiveRecord::Migration
+  def change
+    add_column :users, :stripe_id, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20141004203140) do
+ActiveRecord::Schema.define(version: 20141010010843) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -48,6 +48,7 @@ ActiveRecord::Schema.define(version: 20141004203140) do
     t.string   "time_zone",              default: "Central Time (US & Canada)", null: false
     t.integer  "prompt_delivery_hour",   default: 2,                            null: false
     t.string   "reply_token",                                                   null: false
+    t.string   "stripe_id"
   end
 
   add_index "users", ["email"], name: "index_users_on_email", unique: true, using: :btree


### PR DESCRIPTION
We'd like to allow users to close their account without having to send us an email at `team@trailmix.life`

Closing an account involves 2 steps:
1. Delete user information and entries from Trailmix
2. Delete customer record on Stripe

In order to delete the Stripe customer record, we [need the user's Stripe ID](https://stripe.com/docs/api#delete_customer).

This adds a `stripe_id` column to `User` so we can start persisting the user's Stripe ID. I'll follow up with other PRs to:
- Save the Stripe ID after signup for new users
- Back-fill Stripe IDs for customers that have already signed up
- Add `not null` constraint to `stripe_id`
- Allow users to close their account
