### PR TITLE
Persist Stripe ID on sign up

### DIFF
--- a/app/controllers/subscriptions_controller.rb
+++ b/app/controllers/subscriptions_controller.rb
@@ -3,7 +3,7 @@ class SubscriptionsController < ApplicationController
     user = build_user
 
     if user.valid?
-      create_stripe_customer
+      user.stripe_id = create_stripe_customer.id
       user.save!
       send_welcome_email(user)
       sign_in(user)


### PR DESCRIPTION
Now that we added a column for the Stripe in in https://github.com/codecation/trailmix/pull/111, let's start using it for new customers.
