### PR TITLE
Add transition for back-filling Stripe IDs

### DIFF
--- a/app/transitions/backfill_stripe_id_transition.rb
+++ b/app/transitions/backfill_stripe_id_transition.rb
@@ -1,0 +1,25 @@
+class BackfillStripeIdTransition
+  def self.perform
+    new.perform
+  end
+
+  def perform
+    stripe_customers.each do |stripe_customer|
+      update_stripe_id_for(stripe_customer)
+    end
+  end
+
+  private
+
+  def update_stripe_id_for(stripe_customer)
+    user = User.find_by(email: stripe_customer.email)
+
+    if user && user.stripe_id.blank?
+      user.update_attributes!(stripe_id: stripe_customer.id)
+    end
+  end
+
+  def stripe_customers
+    Stripe::Customer.all(limit: 100)
+  end
+end

--- a/spec/transitions/backfill_stripe_id_transition_spec.rb
+++ b/spec/transitions/backfill_stripe_id_transition_spec.rb
@@ -1,0 +1,45 @@
+describe BackfillStripeIdTransition do
+  before do
+    stub_stripe_customers
+  end
+
+  describe "#perform" do
+    context "for users missing a Stripe ID" do
+      it "fills in their Stripe ID" do
+        first_user = create(:user, email: "first@example.com", stripe_id: nil)
+        second_user = create(:user, email: "second@example.com", stripe_id: nil)
+
+        BackfillStripeIdTransition.perform
+
+        expect(first_user.reload.stripe_id).to eq("first id")
+        expect(second_user.reload.stripe_id).to eq("second id")
+      end
+    end
+
+    context "for users that already have a Stripe ID" do
+      it "does nothing" do
+        user = create(
+          :user,
+          email: "first@example.com",
+          stripe_id: "original stripe id"
+        )
+
+        BackfillStripeIdTransition.perform
+
+        expect(user.reload.stripe_id).to eq("original stripe id")
+      end
+    end
+  end
+
+  def stub_stripe_customers
+    list = double("Stripe::ListObject")
+
+    allow(list).to(receive(:each).and_yield(
+      double("Stripe::Customer", email: "second@example.com", id: "second id")
+    ).and_yield(
+      double("Stripe::Customer", email: "first@example.com", id: "first id")
+    ))
+
+    allow(Stripe::Customer).to(receive(:all).and_return(list))
+  end
+end


### PR DESCRIPTION
This adds a transition for back-filling all existing users with their Stripe customer ID.

We should not run this until https://github.com/codecation/trailmix/pull/112 has been deployed.

The transition can be performed in the console with:

``` ruby
> BackfillStripeIdTransition.perform
```
