### PR TITLE
Add DB constraints to User#stripe_id

### DIFF
--- a/db/migrate/20141010043226_add_not_null_and_index_to_stripe_id.rb
+++ b/db/migrate/20141010043226_add_not_null_and_index_to_stripe_id.rb
@@ -1,0 +1,11 @@
+class AddNotNullAndIndexToStripeId < ActiveRecord::Migration
+  def up
+    change_column :users, :stripe_id, :string, null: false
+    add_index :users, :stripe_id, unique: true
+  end
+
+  def down
+    change_column :users, :stripe_id, :string, null: true
+    remove_index :users, :stripe_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20141010010843) do
+ActiveRecord::Schema.define(version: 20141010043226) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -48,11 +48,12 @@ ActiveRecord::Schema.define(version: 20141010010843) do
     t.string   "time_zone",              default: "Central Time (US & Canada)", null: false
     t.integer  "prompt_delivery_hour",   default: 2,                            null: false
     t.string   "reply_token",                                                   null: false
-    t.string   "stripe_id"
+    t.string   "stripe_id",                                                     null: false
   end
 
   add_index "users", ["email"], name: "index_users_on_email", unique: true, using: :btree
   add_index "users", ["reply_token"], name: "index_users_on_reply_token", unique: true, using: :btree
   add_index "users", ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true, using: :btree
+  add_index "users", ["stripe_id"], name: "index_users_on_stripe_id", unique: true, using: :btree
 
 end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -1,9 +1,11 @@
 FactoryGirl.define do
   sequence(:email) { |n| "user-#{n}@example.com" }
+  sequence(:stripe_id) { |n| "cus_#{n}" }
 
   factory :user do
     email
     password 'abc123'
+    stripe_id
   end
 
   factory :entry do


### PR DESCRIPTION
After https://github.com/codecation/trailmix/pull/112 has been deployed and the transition in https://github.com/codecation/trailmix/pull/113 has been performed, we can add some db constraints to `User#stripe_id`

The build will be red on this branch until we merge https://github.com/codecation/trailmix/pull/112.
