### PR TITLE
Return newest entry by date, not created_at

### DIFF
--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -1,7 +1,7 @@
 class DashboardController < ApplicationController
   def index
     if user_signed_in?
-      @entries = current_user.entries.newest.page(params[:page])
+      @entries = current_user.entries.by_date.page(params[:page])
     else
       redirect_to new_registration_path unless user_signed_in?
     end

--- a/app/models/entry.rb
+++ b/app/models/entry.rb
@@ -2,7 +2,11 @@ class Entry < ActiveRecord::Base
   belongs_to :import
   belongs_to :user
 
-  scope :newest, -> { order("date DESC") }
+  scope :by_date, -> { order("date DESC") }
+
+  def self.newest
+    by_date.first
+  end
 
   def for_today?
     date == Time.zone.now.in_time_zone(user.time_zone).to_date

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -23,7 +23,7 @@ class User < ActiveRecord::Base
   end
 
   def newest_entry
-    entries.last
+    entries.newest
   end
 
   def random_entry

--- a/spec/models/entry_spec.rb
+++ b/spec/models/entry_spec.rb
@@ -3,21 +3,34 @@ require 'rails_helper'
 RSpec.describe Entry, :type => :model do
   it { should belong_to(:import) }
 
-  describe ".newest" do
+  describe ".by_date" do
     it "sorts entries, by date, with the newest first" do
       user = create(:user)
 
       entries = [
-        create(:entry, user: user, date: Time.zone.now, created_at: 1.day.ago),
+        create(:entry, user: user, date: Date.current, created_at: 1.day.ago),
         create(:entry, user: user, date: 1.days.ago, created_at: 3.days.ago),
-        create(:entry, user: user, date: 2.days.ago, created_at: Time.zone.now),
+        create(:entry, user: user, date: 2.days.ago, created_at: Time.current),
         create(:entry, user: user, date: 3.day.ago, created_at: 2.days.ago),
       ]
 
-      newest_entries = user.entries.newest
+      entries_by_date = user.entries.by_date
 
-      expect(newest_entries).to eq(entries),
-        "expected #{entries.map(&:id)}, got #{newest_entries.map(&:id)}"
+      expect(entries_by_date).to(
+        eq(entries),
+        "expected #{entries.map(&:id)}, got #{entries_by_date.map(&:id)}")
+    end
+  end
+
+  describe ".newest" do
+    it "returns the newest dated entry" do
+      user = create(:user)
+      newest_entry = create(:entry, user: user, date: Date.current)
+      create(:entry, user: user, date: 1.day.ago)
+
+      entry = user.entries.newest
+
+      expect(entry).to eq(newest_entry)
     end
   end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -40,10 +40,10 @@ RSpec.describe User, :type => :model do
   end
 
   describe "#newest_entry" do
-    it "returns the newest entry" do
+    it "returns the newest entry by date" do
       user = create(:user)
-      first_entry = create(:entry, user: user, created_at: 1.day.ago)
-      newest_entry = create(:entry, user: user, created_at: Time.zone.now)
+      newest_entry = create(:entry, user: user, date: 1.day.ago)
+      oldest_entry = create(:entry, user: user, date: 2.days.ago)
 
       expect(user.newest_entry).to eq(newest_entry)
     end


### PR DESCRIPTION
We only use this method in tests right now, but it's nice to be consistent with what we mean by "newest".
