### PR TITLE
Add transition for filling in missing subscriptions

### DIFF
--- a/app/transitions/backfill_subscriptions_transition.rb
+++ b/app/transitions/backfill_subscriptions_transition.rb
@@ -1,0 +1,25 @@
+class BackfillSubscriptionsTransition
+  def self.perform
+    new.perform
+  end
+
+  def perform
+    stripe_customers.each do |stripe_customer|
+      create_subscription_for(stripe_customer)
+    end
+  end
+
+  private
+
+  def create_subscription_for(stripe_customer)
+    user = User.find_by(email: stripe_customer.email)
+
+    if user && user.subscription.blank?
+      user.create_subscription!(stripe_customer_id: stripe_customer.id)
+    end
+  end
+
+  def stripe_customers
+    Stripe::Customer.all(limit: 100)
+  end
+end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -1,5 +1,6 @@
 FactoryGirl.define do
   sequence(:email) { |n| "user-#{n}@example.com" }
+  sequence(:stripe_customer_id) { |n| "cus_#{n}" }
 
   factory :user do
     email
@@ -10,6 +11,11 @@ FactoryGirl.define do
     user
     date Time.zone.now
     body 'Entry body'
+  end
+
+  factory :subscription do
+    user
+    stripe_customer_id
   end
 
   factory :import do

--- a/spec/transitions/backfill_subscriptions_transition_spec.rb
+++ b/spec/transitions/backfill_subscriptions_transition_spec.rb
@@ -1,0 +1,48 @@
+describe BackfillSubscriptionsTransition do
+  describe "#perform" do
+    context "for users missing a Subscription" do
+      it "creates one with the correct Stripe customer id" do
+        first_user = create(:user, subscription: nil)
+        second_user = create(:user, subscription: nil)
+        stub_stripe_customers([
+          { email: first_user.email, id: "first id" },
+          { email: second_user.email, id: "second id" }
+        ])
+
+        BackfillSubscriptionsTransition.perform
+
+        first_subscription = first_user.reload.subscription
+        second_subscription = second_user.reload.subscription
+
+        expect(first_subscription.stripe_customer_id).to eq("first id")
+        expect(second_subscription.stripe_customer_id).to eq("second id")
+      end
+    end
+
+    context "for users that already have a Subscription" do
+      it "does nothing" do
+        original_subscription = create(:subscription)
+        user = create(:user, subscription: original_subscription)
+        stub_stripe_customers([
+          { email: user.email, id: "new id" }
+        ])
+
+        BackfillSubscriptionsTransition.perform
+
+        expect(user.reload.subscription).to eq(original_subscription)
+      end
+    end
+  end
+
+  def stub_stripe_customers(customers)
+    customer_list = double("Stripe::ListObject")
+    iterator = allow(customer_list).to(receive(:each))
+
+    customers.inject(iterator) do |iterator, customer|
+      iterator.and_yield(
+        double("Stripe::Customer", email: customer[:email], id: customer[:id]))
+    end
+
+    allow(Stripe::Customer).to(receive(:all).and_return(customer_list))
+  end
+end


### PR DESCRIPTION
Here's a transition to backfill our existing users with a subscription. It can be performed in the console with:

``` ruby
> BackfillSubscriptionsTransition.perform
```
