### PR TITLE
Allow users to close their account

### DIFF
--- a/app/controllers/cancellations_controller.rb
+++ b/app/controllers/cancellations_controller.rb
@@ -1,0 +1,20 @@
+class CancellationsController < ApplicationController
+  before_action :authenticate_user!
+
+  def create
+    create_cancellation
+    current_user.destroy!
+    flash[:notice] = "Your account has been removed and " +
+      "your subscription has been canceled."
+
+    redirect_to dashboard_path
+  end
+
+  private
+
+  def create_cancellation
+    Cancellation.create!(email: current_user.email,
+                         stripe_customer_id: current_user.stripe_customer_id,
+                         reason: params[:reason])
+  end
+end

--- a/app/models/cancellation.rb
+++ b/app/models/cancellation.rb
@@ -1,0 +1,2 @@
+class Cancellation < ActiveRecord::Base
+end

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -1,3 +1,14 @@
 class Subscription < ActiveRecord::Base
   belongs_to :user
+  before_destroy :delete_stripe_subscription
+
+  def stripe_customer
+    @stripe_customer ||= Stripe::Customer.retrieve(stripe_customer_id)
+  end
+
+  private
+
+  def delete_stripe_subscription
+    stripe_customer.subscriptions.map(&:delete)
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -11,6 +11,8 @@ class User < ActiveRecord::Base
 
   before_create :generate_reply_token
 
+  delegate :stripe_customer_id, to: :subscription
+
   def self.promptable(time = Time.zone.now.utc)
     where(prompt_delivery_hour: time.hour)
   end

--- a/app/views/settings/edit.html.erb
+++ b/app/views/settings/edit.html.erb
@@ -3,6 +3,7 @@
   <p class="lead">When would you like your daily email?</p>
 <% end %>
 
+<p>
 <%= form_tag settings_path, method: :put do %>
   <div class="form-group">
     <%= time_zone_select :user,
@@ -22,3 +23,8 @@
 
   <button type="submit" class="btn btn-default btn-lg">Save</button>
 <% end %>
+</p>
+
+<hr />
+
+<%= render "subscriptions/close_account" %>

--- a/app/views/subscriptions/_close_account.html.erb
+++ b/app/views/subscriptions/_close_account.html.erb
@@ -1,0 +1,66 @@
+<p>
+  <small>
+    <%= link_to "Close my account",
+      "#",
+      data: { toggle: "modal", target: "#closeAccount" }
+    %>.
+  </small>
+
+  <div class="modal fade"
+       id="closeAccount"
+       tabindex="-1"
+       role="dialog"
+       aria-labelledby="myModalLabel"
+       aria-hidden="true">
+  <%= form_for Cancellation.new do |f| %>
+    <div class="modal-dialog"><div class="modal-content">
+      <div class="modal-header">
+        <button type="button"
+                class="close"
+                data-dismiss="modal">
+          <span aria-hidden="true">&times;</span>
+          <span class="sr-only">Close</span>
+        </button>
+        <h3 class="modal-title" id="myModalLabel">Close my account :(</h3>
+      </div>
+      <div class="modal-body">
+        <p>
+          When your account is closed, all your information and entries will be
+          permanently removed from Trailmix.
+        </p>
+
+        <p>
+          <strong>This action cannot be undone.</strong>
+        </p>
+
+        <p>
+          Please <strong><%= link_to "export", new_export_path %></strong> your
+          entries now before closing your account.
+        </p>
+
+        <p>
+          If you can provide any feedback to help improve Trailmix for other
+          journalers, we would be very grateful.
+        </p>
+
+        <input type="text"
+              class="form-control input-lg"
+              id="reason"
+              name="reason"
+              placeholder="Any feedback for us?">
+      </div>
+      <div class="modal-footer">
+        <button type="button"
+                class="btn btn-default btn-lg"
+                data-dismiss="modal">
+                Cancel
+        </button>
+        <button type="submit"
+                class="btn btn-primary btn-lg">
+                Close my account
+        </button>
+      </div>
+    </div></div>
+  <% end %>
+  </div>
+</p>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,6 +12,7 @@ Rails.application.routes.draw do
 
   get "/pages/ohlife_refugees", to: redirect("/pages/ohlife-alternative")
 
+  resources :cancellations, only: [:create]
   resource :export, only: [:new]
   resources :imports, only: [:new, :create]
   resource :settings, only: [:edit, :update]

--- a/db/migrate/20141011191307_create_cancellation.rb
+++ b/db/migrate/20141011191307_create_cancellation.rb
@@ -1,0 +1,11 @@
+class CreateCancellation < ActiveRecord::Migration
+  def change
+    create_table :cancellations do |t|
+      t.string :email, null: false
+      t.string :stripe_customer_id, null: false
+      t.text :reason
+
+      t.timestamps null: false
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,10 +11,18 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20141010201317) do
+ActiveRecord::Schema.define(version: 20141011191307) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "cancellations", force: true do |t|
+    t.string   "email",              null: false
+    t.string   "stripe_customer_id", null: false
+    t.text     "reason"
+    t.datetime "created_at",         null: false
+    t.datetime "updated_at",         null: false
+  end
 
   create_table "entries", force: true do |t|
     t.integer  "user_id",    null: false

--- a/spec/controllers/cancellations_controller_spec.rb
+++ b/spec/controllers/cancellations_controller_spec.rb
@@ -1,0 +1,65 @@
+require "rails_helper"
+
+describe CancellationsController do
+  describe "#create" do
+    context "when signed in" do
+      it "destroys the current user" do
+        subscription = create(:subscription)
+        user = subscription.user
+        sign_in(user)
+
+        post :create, id: user.id
+
+        expect(User.count).to be_zero
+      end
+
+      it "creates a Cancellation" do
+        subscription = create(:subscription)
+        user = subscription.user
+
+        sign_in(user)
+        post :create, id: user.id, reason: "I'm done journaling"
+        cancellation = Cancellation.last
+
+        expect(cancellation.reason).to eq("I'm done journaling")
+        expect(cancellation.stripe_customer_id).to(
+          eq(subscription.stripe_customer_id)
+        )
+      end
+
+      it "cancels the Stripe subscription" do
+        subscription = create(:subscription)
+        user = subscription.user
+        stripe_subscription =
+          stub_stripe(subscription.stripe_customer_id)
+        sign_in(user)
+
+        post :create, id: user.id
+
+        expect(stripe_subscription).to(have_received(:delete))
+      end
+    end
+
+    context "when signed out" do
+      it "redirects to sign in" do
+        post :create, id: "not an id"
+
+        expect(response).to redirect_to(new_user_session_path)
+      end
+    end
+
+    def stub_stripe(customer_id)
+      double("Stripe::Subscription", delete: true).tap do |subscription|
+        customer = double(
+          "Stripe::Customer",
+          id: customer_id,
+          subscriptions: [subscription]
+        )
+
+        allow(Stripe::Customer).to(
+          receive(:retrieve).with(customer_id).and_return(customer)
+        )
+      end
+    end
+  end
+end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -1,9 +1,15 @@
 FactoryGirl.define do
   sequence(:email) { |n| "user-#{n}@example.com" }
+  sequence(:stripe_customer_id) { |n| "cus_#{n}" }
 
   factory :user do
     email
     password 'abc123'
+  end
+
+  factory :subscription do
+    user
+    stripe_customer_id
   end
 
   factory :entry do

--- a/spec/features/user_cancels_account_spec.rb
+++ b/spec/features/user_cancels_account_spec.rb
@@ -1,0 +1,16 @@
+feature "User cancels account" do
+  scenario "and their information is removed" do
+    subscription = create(:subscription)
+    user = subscription.user
+    entry = create(:entry, user: user)
+
+    login_as(user)
+    visit edit_settings_path
+    click_link "Close my account"
+    fill_in :reason, with: "I decided I hate journaling."
+    click_button "Close my account"
+
+    expect(page).to have_content("account has been removed")
+    expect(page).to have_content("subscription has been canceled")
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -84,4 +84,13 @@ RSpec.describe User, :type => :model do
       end
     end
   end
+
+  describe "#stripe_customer_id" do
+    it "delegates to the subscription" do
+      subscription = create(:subscription)
+      user = subscription.user
+
+      expect(user.stripe_customer_id).to eq(subscription.stripe_customer_id)
+    end
+  end
 end


### PR DESCRIPTION
This can be merged once we've run the transition in https://github.com/codecation/trailmix/pull/119.

If someone decides they no longer want to use Trailmix, we should make it super easy to close their account.

This adds a "close my account" link in settings.

All the user's information, their entries, and their Stripe subscription are permanently removed.

![close-account](https://cloud.githubusercontent.com/assets/65323/4601501/79c67726-5104-11e4-8cb2-285645bb9f17.gif)
