### PR TITLE
Let the db find us a random entry; it's faster.

### DIFF
--- a/app/models/entry.rb
+++ b/app/models/entry.rb
@@ -8,6 +8,10 @@ class Entry < ActiveRecord::Base
     by_date.first
   end
 
+  def self.random
+    order("RANDOM()").first
+  end
+
   def for_today?
     date == Time.zone.now.in_time_zone(user.time_zone).to_date
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -28,7 +28,7 @@ class User < ActiveRecord::Base
   end
 
   def random_entry
-    entries.sample
+    entries.random
   end
 
   def prompt_delivery_hour

--- a/spec/models/entry_spec.rb
+++ b/spec/models/entry_spec.rb
@@ -34,6 +34,14 @@ RSpec.describe Entry, :type => :model do
     end
   end
 
+  describe ".random" do
+    it "returns a random entry" do
+      entry = create(:entry)
+
+      expect(Entry.random).to eq(entry)
+    end
+  end
+
   describe "#for_today?" do
     context "when the entry is dated for today" do
       it "returns true" do


### PR DESCRIPTION
Every time we send someone a daily email, we're [loading all their entries](https://github.com/codecation/trailmix/blob/443b102136ae379c0e23ce0bb25894374f758dec/app/models/user.rb#L31) into memory in order to select one at random. For some users who have a couple thousand entries already, this is not ideal. :grin: 

PostgreSQL to the rescue! See this very detailed and scientific benchmark (on staging):

``` ruby
> def time
>   start = Time.current
>
>   yield
>
>   puts "#{(Time.current - start).round(3)} seconds"
> end

> user.entries.count
=> 1482

> time { user.entries.sample }
0.128 seconds

> time { user.entries.order("RANDOM()").first }
0.007 seconds
```
