### PR TITLE
Match intent of Export#filename test to signature

### DIFF
--- a/app/models/export.rb
+++ b/app/models/export.rb
@@ -1,11 +1,10 @@
 class Export
-  def initialize(user, today = Time.current.to_date)
+  def initialize(user)
     @user = user
-    @today = today
   end
 
   def filename
-    "trailmix-#{today}.json"
+    "trailmix-#{Date.current}.json"
   end
 
   def to_json
@@ -14,5 +13,5 @@ class Export
 
   private
 
-  attr_reader :user, :today
+  attr_reader :user
 end

--- a/spec/models/export_spec.rb
+++ b/spec/models/export_spec.rb
@@ -1,12 +1,13 @@
 describe Export do
   describe "#filename" do
     it "includes today's date" do
-      today = Date.new(2014, 1, 2)
-      user = double(:user)
+      Timecop.freeze(Time.utc(2014, 1, 2)) do
+        export = Export.new(double(:user))
 
-      export = Export.new(user, today)
+        filename = export.filename
 
-      expect(export.filename).to eq("trailmix-2014-01-02.json")
+        expect(filename).to eq("trailmix-2014-01-02.json")
+      end
     end
   end
 


### PR DESCRIPTION
The previous test's description did not match its use in the test;
it said the Method Under Test's implementation would use today's date
but instead used the value of the constructor's parameter.

Since the application never uses the second parameter in the constructor,
it looks like the parameter was only used for testability.

We can instead safely stub today's date using Timecop.

Also:
- Use shorter, Law of Demeter-friendly `Date.current`.
- Since the Method Under Test is `#filename`,
  invoke it during the Exercise phase,
  separated by blank lines.
