### PR TITLE
Remove README note about Heroku access

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,10 +51,6 @@ with the necessary dependencies to run and test this app:
 
     % ./bin/setup
 
-
-(Note: the final steps of this script will fail, because you don't have access
-to our heroku application.)
-
 The script also assumes you have a machine equipped with Ruby, Postgres, etc.
 If not, set up your machine with [this script].
 

--- a/bin/setup
+++ b/bin/setup
@@ -29,20 +29,13 @@ if ! command -v foreman &>/dev/null; then
   echo "See https://github.com/ddollar/foreman for install instructions."
 fi
 
-# Set up staging and production git remotes.
-git remote add staging git@heroku.com:trailmix-staging.git || true
-git remote add production git@heroku.com:trailmix-production.git || true
-
-# Join the staging and production apps.
+# Set up staging and production apps.
 if heroku join --app trailmix-staging &> /dev/null; then
+  git remote add staging git@heroku.com:trailmix-staging.git || true
   echo 'You are a collaborator on the "trailmix-staging" Heroku app'
-else
-  echo 'Ask for access to the "trailmix-staging" Heroku app'
 fi
 
 if heroku join --app trailmix-production &> /dev/null; then
+  git remote add production git@heroku.com:trailmix-production.git || true
   echo 'You are a collaborator on the "trailmix-production" Heroku app'
-else
-  echo 'Ask for access to the "trailmix-production" Heroku app'
 fi
-


### PR DESCRIPTION
[Suspenders](https://github.com/thoughtbot/suspenders)' (the generator used to create the Trailmix Rails app)
`./bin/setup` script doesn't "fail" in a non-zero exit status sense.

The `heroku join` lines are protected by `if` statements:

``` bash
if heroku join --app trailmix-staging &> /dev/null; then

if heroku join --app trailmix-production &> /dev/null; then
```

The failing branch of the conditionals used to print messages to `stdout`:

> Ask for access to the "trailmix-staging" Heroku app
> Ask for access to the "trailmix-production" Heroku app

This commit removes those messages to avoid a situation where
open-source contributors ask for access to the Heroku apps.
