### PR TITLE
Place interesting entries in the prompt email

### DIFF
--- a/app/models/prompt_entry.rb
+++ b/app/models/prompt_entry.rb
@@ -1,0 +1,38 @@
+class PromptEntry
+  def initialize(entries, time_zone)
+    @entries = entries
+    @time_zone = time_zone
+  end
+
+  def self.best(entries, time_zone)
+    new(entries, time_zone).best
+  end
+
+  def best
+    interesting || random
+  end
+
+  private
+
+  attr_reader :entries, :time_zone
+
+  def interesting
+    entries.by_date.where(date: dates).last
+  end
+
+  def random
+    entries.random
+  end
+
+  def dates
+    durations.map { |duration| today - duration }
+  end
+
+  def durations
+    [1.year, 1.month, 1.week]
+  end
+
+  def today
+    Time.current.in_time_zone(time_zone).to_date
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -29,8 +29,8 @@ class User < ActiveRecord::Base
     entries.newest
   end
 
-  def random_entry
-    entries.random
+  def prompt_entry
+    PromptEntry.best(entries, time_zone)
   end
 
   def prompt_delivery_hour

--- a/app/workers/prompt_worker.rb
+++ b/app/workers/prompt_worker.rb
@@ -3,7 +3,7 @@ class PromptWorker
 
   def perform(user_id)
     user = User.find(user_id)
-    entry = user.random_entry
+    entry = user.prompt_entry
 
     PromptMailer.prompt(user, entry).deliver
   end

--- a/spec/models/prompt_entry_spec.rb
+++ b/spec/models/prompt_entry_spec.rb
@@ -1,0 +1,60 @@
+describe PromptEntry do
+  describe "#best" do
+    context "when there's an entry from one year ago" do
+      it "returns that entry" do
+        Timecop.freeze(2014, 1, 2, 20) do # 8PM UTC
+          user = create(:user, time_zone: "Guam") # UTC+10
+          one_year_ago = Date.new(2013, 1, 3)
+          one_year_entry = create(:entry, user: user, date: one_year_ago)
+          create(:entry, user: user, date: 1.week.ago)
+
+          best = PromptEntry.new(user.entries, user.time_zone).best
+
+          expect(best).to eq(one_year_entry)
+        end
+      end
+    end
+
+    context "when there's an entry from one month ago" do
+      it "returns that entry" do
+        Timecop.freeze(2014, 1, 2, 20) do # 8PM UTC
+          user = create(:user, time_zone: "Guam") # UTC+10
+          one_month_ago = Date.new(2013, 12, 3)
+          create(:entry, user: user, date: 1.week.ago)
+          one_month_entry = create(:entry, user: user, date: one_month_ago)
+
+          best = PromptEntry.new(user.entries, user.time_zone).best
+
+          expect(best).to eq(one_month_entry)
+        end
+      end
+    end
+
+    context "when there's an entry from one week ago" do
+      it "returns that entry" do
+        Timecop.freeze(2014, 1, 2, 20) do # 8PM UTC
+          user = create(:user, time_zone: "Guam") # UTC+10
+          one_week_ago = Date.new(2013, 12, 27)
+          create(:entry, user: user, date: 2.years.ago)
+          one_week_entry = create(:entry, user: user, date: one_week_ago)
+
+          best = PromptEntry.new(user.entries, user.time_zone).best
+
+          expect(best).to eq(one_week_entry)
+        end
+      end
+    end
+
+    context "when there are no interesting entries" do
+      it "returns a random entry" do
+        user = create(:user)
+        random_entry = double(:entry)
+        allow(user.entries).to(receive(:random).and_return(random_entry))
+
+        best = PromptEntry.new(user.entries, user.time_zone).best
+
+        expect(best).to eq(random_entry)
+      end
+    end
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -50,12 +50,16 @@ RSpec.describe User, :type => :model do
     end
   end
 
-  describe "#random_entry" do
-    it "returns a random entry" do
+  describe "#prompt_entry" do
+    it "delegates to PromptEntry" do
       user = create(:user)
-      entry = create(:entry, user: user)
+      allow(PromptEntry).to(
+        receive(:best).with(user.entries, user.time_zone).
+        and_return("best entry"))
 
-      expect(user.random_entry).to eq(entry)
+      entry = user.prompt_entry
+
+      expect(entry).to eq("best entry")
     end
   end
 


### PR DESCRIPTION
Entries from 1 year ago, 1 month ago, and 1 week ago are more interesting than random entries for most people.

This PR adds an interesting entry to the daily prompt email if we have one. If not, it continues to use a random one.
