### PR TITLE
Show age for previous entry in user's time zone

### DIFF
--- a/app/mailers/prompt_mailer.rb
+++ b/app/mailers/prompt_mailer.rb
@@ -3,28 +3,29 @@ class PromptMailer < ActionMailer::Base
 
   def prompt(user, entry)
     @entry = entry
+    @date = Time.current.in_time_zone(user.time_zone).to_date
 
     mail(
       from: "Trailmix <#{user.reply_email}>",
       to: user.email,
-      subject: Subject.new(user)
+      subject: Subject.new(user, @date)
     )
   end
 
   class Subject
-    def initialize(user, date = Time.zone.now)
+    def initialize(user, date)
       @user = user
       @date = date
     end
 
     def to_s
-      "It's #{today}. How was your day?"
+      "It's #{date}. How was your day?"
     end
 
     private
 
-    def today
-      I18n.l(@date.in_time_zone(@user.time_zone), format: :for_prompt)
+    def date
+      I18n.l(@date, format: :for_prompt)
     end
   end
 end

--- a/app/views/prompt_mailer/prompt.text.erb
+++ b/app/views/prompt_mailer/prompt.text.erb
@@ -3,7 +3,7 @@
 Simply reply to this email with your entry.
 
 <% if @entry %>
-Remember this? <%= (time_ago_in_words(@entry.date)).capitalize %> ago you wrote the following:
+Remember this? <%= (distance_of_time_in_words(@date, @entry.date)).capitalize %> ago you wrote the following:
 
 ----------------------
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -5,6 +5,8 @@ en:
         "%m/%d/%Y"
       day_of_week:
         "%A"
+      for_prompt:
+        "%A, %b %-d" # Thursday, Sept 17
       month_day_year:
         "%B %-d, %Y"
       month_day:
@@ -20,5 +22,3 @@ en:
         "%b %-d, %Y"
       short:
         "%B %d"
-      for_prompt:
-        "%A, %b %-d" # Thursday, Sept 17

--- a/spec/mailers/prompt_mailer_spec.rb
+++ b/spec/mailers/prompt_mailer_spec.rb
@@ -21,19 +21,13 @@ describe PromptMailer do
 
     context "when the user has set their timezone" do
       it "shows today's date in their timezone" do
-        Timecop.freeze(Time.utc(2014, 1, 1)) do
-          user = create(:user)
+        Timecop.freeze(Time.utc(2014, 1, 1, 20)) do
+          user = create(:user, time_zone: "Guam") # UTC+10
           entry = build_stubbed(:entry)
 
-          user.time_zone = "Pacific Time (US & Canada)"
           mail = PromptMailer.prompt(user, entry)
 
-          expect(mail.subject).to include("Tuesday")
-
-          user.time_zone = "Melbourne"
-          mail = PromptMailer.prompt(user, entry)
-
-          expect(mail.subject).to include("Wednesday")
+          expect(mail.subject).to include("Jan 2")
         end
       end
     end
@@ -48,13 +42,15 @@ describe PromptMailer do
         expect(mail.body.encoded).to include(entry.body)
       end
 
-      it "says how long ago the past entry was" do
-        user = create(:user)
-        entry = create(:entry, user: user, date: 1.year.ago)
+      it "says how long ago the past entry was in the user's time zone" do
+        Timecop.freeze(Time.utc(2014, 1, 3, 14)) do
+          user = create(:user, time_zone: "Guam") # UTC+10
+          entry = create(:entry, user: user, date: Date.new(2014, 1, 1))
 
-        mail = PromptMailer.prompt(user, entry)
+          mail = PromptMailer.prompt(user, entry)
 
-        expect(mail.body.encoded).to include("About 1 year ago")
+          expect(mail.body.encoded).to include("3 days ago")
+        end
       end
     end
   end

--- a/spec/models/email_processor_spec.rb
+++ b/spec/models/email_processor_spec.rb
@@ -91,9 +91,9 @@ describe EmailProcessor do
     end
 
     context "when the entry is a response to yesterday's email" do
-      it "sets the entry date to yesterday's date in the user's time zone" do
-        yesterday = Time.utc(2014, 1, 1, 20) # 8 PM UTC
-        user = create(:user, time_zone: "Guam") # UTC+10
+      it "sets the entry date to yesterday's date" do
+        yesterday = Date.new(2014, 1, 2)
+        user = create(:user)
         email = create(
           :griddler_email,
           to: [{ token: user.reply_token }],


### PR DESCRIPTION
Since we've merged https://github.com/codecation/trailmix/pull/124, I'm now seeing entries from exactly one week ago in each daily email. The entries are great, but the age message is incorrect. I'm seeing:

> Remember this? 8 days ago you wrote the following:

The reason this is happening is because in UTC land, my week old entry is actually 8 days old. But in PST land, where I live, it's 7 days old.

This PR makes it so that we use the user's time zone for the age message.
