### PR TITLE
Make signing out work without JavaScript.

### DIFF
--- a/app/assets/stylesheets/base/_header.css.scss
+++ b/app/assets/stylesheets/base/_header.css.scss
@@ -21,8 +21,12 @@
   .navbar-right {
     text-align: center;
 
-    li a {
+    li a, li input[type=submit] {
+      background: none;
+      border: none;
       color: $brown;
+      line-height: 18px;
+      padding: 10px 15px;
 
       &:hover {
         color: $brown;

--- a/app/views/application/_navbar.html.erb
+++ b/app/views/application/_navbar.html.erb
@@ -29,7 +29,7 @@
             <%= link_to "Settings", edit_settings_path %>
           </li>
           <li>
-          <%= link_to "Sign out", destroy_user_session_path, method: :delete %>
+            <%= button_to "Sign out", destroy_user_session_path, method: :delete %>
           </li>
           <li>
             <%= link_to search_path,

--- a/spec/features/user_signs_out_spec.rb
+++ b/spec/features/user_signs_out_spec.rb
@@ -6,7 +6,7 @@ feature "User signs out" do
     fill_in "user_password", with: user.password
     click_button "Sign in"
 
-    click_link "Sign out"
+    click_button "Sign out"
 
     expect(current_path).to eq new_registration_path
   end


### PR DESCRIPTION
Links will only produce GET requests unless JavaScript is used to make a
DELETE ajax request. Using a button a DELETE can be emulated over POST to
make it possible to log out without JavaScript.
