### PR TITLE
Allow users to update their credit cards

### DIFF
--- a/app/assets/stylesheets/base/_body.css.scss
+++ b/app/assets/stylesheets/base/_body.css.scss
@@ -50,7 +50,7 @@ mark {
   background: $brown;
   border-color: $brown;
 
-  &:hover, &:focus {
+  &:hover, &:focus, &:disabled {
     color: white;
     background: $brown;
     border-color: $brown;

--- a/app/controllers/credit_cards_controller.rb
+++ b/app/controllers/credit_cards_controller.rb
@@ -1,0 +1,16 @@
+class CreditCardsController < ApplicationController
+  layout "skinny"
+
+  def edit
+  end
+
+  def update
+    stripe_customer =
+      Stripe::Customer.retrieve(current_user.stripe_customer_id)
+    stripe_customer.card = params[:stripeToken]
+    stripe_customer.save
+
+    flash.notice = "Credit card updated successfully"
+    redirect_to action: :edit
+  end
+end

--- a/app/views/credit_cards/_stripe_javascript.html.erb
+++ b/app/views/credit_cards/_stripe_javascript.html.erb
@@ -1,0 +1,42 @@
+<script type="text/javascript" src="https://js.stripe.com/v2/"></script>
+
+<script type="text/javascript">
+  Stripe.setPublishableKey("<%= ENV.fetch('STRIPE_PUBLISHABLE_KEY') %>");
+
+  var stripeResponseHandler = function(status, response) {
+    var $form = $('#credit-card-update');
+
+    if (response.error) {
+      // Show the errors on the form
+      var paymentErrors = $form.find('.js-payment-errors');
+      paymentErrors.text(response.error.message).removeClass('hidden');
+
+      $form.find('button').button('reset');
+    } else {
+      // token contains id, last4, and card type
+      var token = response.id;
+
+      // Disable all credit card fields so they aren't submitted to our server
+      $form.find(':text').prop('disabled', true);
+
+      // Insert the token into the form so it gets submitted to the server
+      $form.append($('<input type="hidden" name="stripeToken" />').val(token));
+      // and re-submit
+      $form.get(0).submit();
+    }
+  };
+
+  jQuery(function($) {
+    $('#credit-card-update').submit(function(e) {
+      var $form = $(this);
+
+      // Disable the submit button to prevent repeated clicks
+      $form.find('button').button('loading');
+
+      Stripe.card.createToken($form, stripeResponseHandler);
+
+      // Prevent the form from submitting with the default action
+      return false;
+    });
+  });
+</script>

--- a/app/views/credit_cards/edit.html.erb
+++ b/app/views/credit_cards/edit.html.erb
@@ -1,0 +1,50 @@
+<% content_for :javascript do %>
+  <%= render "stripe_javascript" %>
+<% end %>
+
+<% content_for :header do %>
+  <p><h1>Update credit card</h1></p>
+<% end %>
+
+<p>
+<%= form_tag credit_card_path, method: :put, id: "credit-card-update" do %>
+  <p class="js-payment-errors alert alert-danger hidden"></p>
+
+  <div class="form-group">
+    <%= text_field_tag :number, nil,
+      class: "form-control input-lg",
+      placeholder: "Number (1234-1234-1234-1234)",
+      data: { stripe: "number" }
+    %>
+  </div>
+
+  <div class="form-group">
+    <%= text_field_tag :exp_month, nil,
+      class: "form-control input-lg",
+      placeholder: "Month (MM)",
+      data: { stripe: "exp-month" }
+    %>
+  </div>
+
+  <div class="form-group">
+    <%= text_field_tag :exp_year, nil,
+      class: "form-control input-lg",
+      placeholder: "Year (YY)",
+      data: { stripe: "exp-year" }
+    %>
+  </div>
+
+  <div class="form-group">
+    <%= text_field_tag :cvc, nil,
+      class: "form-control input-lg",
+      placeholder: "CVC (1234)",
+      data: { stripe: "cvc" }
+    %>
+  </div>
+
+  <%= button_tag "Update credit card",
+    class: "btn btn-default btn-lg",
+    data: { loading_text: "Updating..." }
+  %>
+<% end %>
+<p>

--- a/app/views/settings/edit.html.erb
+++ b/app/views/settings/edit.html.erb
@@ -27,4 +27,7 @@
 
 <hr />
 
-<%= render "subscriptions/close_account" %>
+<p>
+  <small><%= link_to "Update credit card", edit_credit_card_path %> |</small>
+  <%= render "subscriptions/close_account" %>
+</p>

--- a/app/views/subscriptions/_close_account.html.erb
+++ b/app/views/subscriptions/_close_account.html.erb
@@ -1,66 +1,64 @@
-<p>
-  <small>
-    <%= link_to "Close my account",
-      "#",
-      data: { toggle: "modal", target: "#closeAccount" }
-    %>.
-  </small>
+<small>
+  <%= link_to "Close my account",
+    "#",
+    data: { toggle: "modal", target: "#closeAccount" }
+  %>
+</small>
 
-  <div class="modal fade"
-       id="closeAccount"
-       tabindex="-1"
-       role="dialog"
-       aria-labelledby="myModalLabel"
-       aria-hidden="true">
-  <%= form_for Cancellation.new do |f| %>
-    <div class="modal-dialog"><div class="modal-content">
-      <div class="modal-header">
-        <button type="button"
-                class="close"
-                data-dismiss="modal">
-          <span aria-hidden="true">&times;</span>
-          <span class="sr-only">Close</span>
-        </button>
-        <h3 class="modal-title" id="myModalLabel">Close my account :(</h3>
-      </div>
-      <div class="modal-body">
-        <p>
-          When your account is closed, all your information and entries will be
-          permanently removed from Trailmix.
-        </p>
+<div class="modal fade"
+     id="closeAccount"
+     tabindex="-1"
+     role="dialog"
+     aria-labelledby="myModalLabel"
+     aria-hidden="true">
+<%= form_for Cancellation.new do |f| %>
+  <div class="modal-dialog"><div class="modal-content">
+    <div class="modal-header">
+      <button type="button"
+              class="close"
+              data-dismiss="modal">
+        <span aria-hidden="true">&times;</span>
+        <span class="sr-only">Close</span>
+      </button>
+      <h3 class="modal-title" id="myModalLabel">Close my account :(</h3>
+    </div>
+    <div class="modal-body">
+      <p>
+        When your account is closed, all your information and entries will be
+        permanently removed from Trailmix.
+      </p>
 
-        <p>
-          <strong>This action cannot be undone.</strong>
-        </p>
+      <p>
+        <strong>This action cannot be undone.</strong>
+      </p>
 
-        <p>
-          Please <strong><%= link_to "export", new_export_path %></strong> your
-          entries now before closing your account.
-        </p>
+      <p>
+        Please <strong><%= link_to "export", new_export_path %></strong> your
+        entries now before closing your account.
+      </p>
 
-        <p>
-          If you can provide any feedback to help improve Trailmix for other
-          journalers, we would be very grateful.
-        </p>
+      <p>
+        If you can provide any feedback to help improve Trailmix for other
+        journalers, we would be very grateful.
+      </p>
 
-        <input type="text"
-              class="form-control input-lg"
-              id="reason"
-              name="reason"
-              placeholder="Any feedback for us?">
-      </div>
-      <div class="modal-footer">
-        <button type="button"
-                class="btn btn-default btn-lg"
-                data-dismiss="modal">
-                Cancel
-        </button>
-        <button type="submit"
-                class="btn btn-primary btn-lg">
-                Close my account
-        </button>
-      </div>
-    </div></div>
-  <% end %>
-  </div>
-</p>
+      <input type="text"
+            class="form-control input-lg"
+            id="reason"
+            name="reason"
+            placeholder="Any feedback for us?">
+    </div>
+    <div class="modal-footer">
+      <button type="button"
+              class="btn btn-default btn-lg"
+              data-dismiss="modal">
+              Cancel
+      </button>
+      <button type="submit"
+              class="btn btn-primary btn-lg">
+              Close my account
+      </button>
+    </div>
+  </div></div>
+<% end %>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,6 +13,7 @@ Rails.application.routes.draw do
   get "/pages/ohlife_refugees", to: redirect("/pages/ohlife-alternative")
 
   resources :cancellations, only: [:create]
+  resource :credit_card, only: [:edit, :update]
   resources :entries, only: [:index]
   resource :export, only: [:new]
   resources :imports, only: [:new, :create]

--- a/spec/features/user_updates_credit_card_spec.rb
+++ b/spec/features/user_updates_credit_card_spec.rb
@@ -1,0 +1,23 @@
+require "rails_helper"
+
+feature "User updates their credit card" do
+  scenario "successfully" do
+    user = create(:user)
+    create(:subscription, user: user)
+
+    login_as(user)
+    update_credit_card
+
+    expect(page).to have_content("Credit card updated successfully")
+  end
+
+  def update_credit_card
+    visit edit_settings_path
+    click_link "Update credit card"
+    fill_in "number", with: "4242424242424242"
+    fill_in "exp_month", with: "04"
+    fill_in "exp_year", with: "2016"
+    fill_in "cvc", with: "216"
+    click_button "Update credit card"
+  end
+end


### PR DESCRIPTION
- Uses our own credit card form because Stripe Checkout isn't a great
  fit for this (requires we show a price, looks like we're going to charge
  users again).
- Uses Stripe's non-checkout js to update the card. Prevents card info
  from hitting our servers, handles errors gracefully (meaning we can
  ignore them in our controller action), and gives us a token we can than
  associate with the customer.
