### PR TITLE
Allow users to change their passwords while signed in

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -75,7 +75,7 @@ GEM
       rack (>= 1.0.0)
       rack-test (>= 0.5.4)
       xpath (~> 2.0)
-    capybara-webkit (1.3.0)
+    capybara-webkit (1.3.1)
       capybara (>= 2.0.2, < 2.5.0)
       json
     carrierwave (0.10.0)

--- a/app/assets/stylesheets/base/_form.css.scss
+++ b/app/assets/stylesheets/base/_form.css.scss
@@ -7,3 +7,7 @@ input[type]:focus {
 #sign-up-button-tooltip {
   display: inline-block;
 }
+
+.hint {
+  font-size: 80%;
+}

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,6 +3,7 @@ class User < ActiveRecord::Base
          :recoverable,
          :rememberable,
          :trackable,
+         :registerable,
          :validatable
 
   has_many :entries, dependent: :destroy

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -4,7 +4,7 @@
   <%= f.error_notification %>
 
   <div class="form-inputs">
-    <%= f.input :email, as: :hidden, value: resource.email, required: true, autofocus: true %>
+    <%= f.input :email, required: true, autofocus: true %>
 
     <% if devise_mapping.confirmable? && resource.pending_reconfirmation? %>
       <p>Currently waiting confirmation for: <%= resource.unconfirmed_email %></p>

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -1,0 +1,23 @@
+<h2>Edit Password</h2>
+
+<%= simple_form_for(resource, as: resource_name, url: user_registration_path(resource_name), html: { method: :patch }) do |f| %>
+  <%= f.error_notification %>
+
+  <div class="form-inputs">
+    <%= f.input :email, as: :hidden, value: resource.email, required: true, autofocus: true %>
+
+    <% if devise_mapping.confirmable? && resource.pending_reconfirmation? %>
+      <p>Currently waiting confirmation for: <%= resource.unconfirmed_email %></p>
+    <% end %>
+
+    <%= f.input :password, autocomplete: "off", hint: "leave it blank if you don't want to change it", required: false %>
+    <%= f.input :password_confirmation, required: false %>
+    <%= f.input :current_password, hint: "we need your current password to confirm your changes", required: true %>
+  </div>
+
+  <div class="form-actions">
+    <%= f.button :submit, "Update" %>
+  </div>
+<% end %>
+
+<%= link_to "Back", :back %>

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -1,0 +1,17 @@
+<h2>Sign up</h2>
+
+<%= simple_form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
+  <%= f.error_notification %>
+
+  <div class="form-inputs">
+    <%= f.input :email, required: true, autofocus: true %>
+    <%= f.input :password, required: true %>
+    <%= f.input :password_confirmation, required: true %>
+  </div>
+
+  <div class="form-actions">
+    <%= f.button :submit, "Sign up" %>
+  </div>
+<% end %>
+
+<%= render "devise/shared/links" %>

--- a/app/views/settings/edit.html.erb
+++ b/app/views/settings/edit.html.erb
@@ -29,5 +29,6 @@
 
 <p>
   <small><%= link_to "Update credit card", edit_credit_card_path %> |</small>
+  <small><%= link_to "Change password", edit_user_registration_path %> |</small>
   <%= render "subscriptions/close_account" %>
 </p>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,9 @@
 Rails.application.routes.draw do
-  devise_for :users
+  devise_for :users, :skip => [:registrations]
+    as :user do
+      get 'users/edit' => 'devise/registrations#edit', :as => 'edit_user_registration'
+      patch 'users/:id' => 'devise/registrations#update', :as => 'user_registration'
+    end
 
   mount_griddler
 

--- a/spec/features/user_changes_password_spec.rb
+++ b/spec/features/user_changes_password_spec.rb
@@ -1,0 +1,32 @@
+feature "User changes password" do
+  before :each do
+    user = create(:user)
+    login_as(user)
+    visit edit_settings_path
+    click_link "Change password"
+  end
+
+  scenario "with bad info" do
+
+    fill_in :user_password, :with => "asdgs"
+    fill_in :user_password_confirmation, :with => "BananaM0nkey123"
+    fill_in :user_current_password, :with => "sadfdsafs"
+    click_button "Update"
+
+    expect(page).to have_content("Please review the problems below:")
+    expect(current_path).to eq(user_registration_path(:user))
+
+  end
+
+  scenario "with correct info" do
+
+    fill_in :user_password, :with => "BananaM0nkey123"
+    fill_in :user_password_confirmation, :with => "BananaM0nkey123"
+    fill_in :user_current_password, :with => "abc123"
+    click_button "Update"
+
+    expect(page).to have_content("Your account has been updated successfully.")
+    expect(current_path).to eq(root_path)
+
+  end
+end


### PR DESCRIPTION
This is directly related to an email correspondence with Chris Hunt.

My basic steps were:
1. Write tests
2. `rails generate devise:views -v registrations`
3. Edit `routes.rb` and appropriate view files
4. Tests pass yay

I saw this also allows people to change their email address, but I do not know if this is something you want to allow. The password change functionality has test coverage, but the email change functionality does not.

As this is my first PR for any OSS project ever, I would love any feedback you can provide!