### PR TITLE
Reword a failing spec to better illustrate a bug

### DIFF
--- a/spec/models/email_processor_spec.rb
+++ b/spec/models/email_processor_spec.rb
@@ -92,19 +92,21 @@ describe EmailProcessor do
       end
     end
 
-    context "when the entry is a response to yesterday's email" do
-      it "sets the entry date to yesterday's date" do
-        yesterday = Date.new(2014, 1, 2)
-        user = create(:user)
-        email = create(
-          :griddler_email,
-          to: [{ token: user.reply_token }],
-          subject: "Re: #{PromptMailer::Subject.new(user, yesterday)}"
-        )
+    context "when the entry is a response to a past day's email" do
+      pending "sets the entry date to the email's date" do
+        past_day = Date.new(2014, 1, 2)
+        Timecop.freeze(2015, 1, 1) do
+          user = create(:user)
+          email = create(
+            :griddler_email,
+            to: [{ token: user.reply_token }],
+            subject: "Re: #{PromptMailer::Subject.new(user, past_day)}"
+          )
 
-        EmailProcessor.new(email).process
+          EmailProcessor.new(email).process
 
-        expect(user.newest_entry.date).to eq(Date.new(2014, 1, 2))
+          expect(user.newest_entry.date).to eq(past_day)
+        end
       end
     end
   end


### PR DESCRIPTION
The email parser that checks for the date of an entry assumes that the
response was sent in the current year. This becomes a problem around new
year's, when responses to any previous email will be marked as future
responses.

For example,

```
12/30/2014 : prompt email sent
 1/ 1/2015 : response sent
–---------
12/30/2015 : parsed entry date
```