### PR TITLE
Fix entries that have dates in the future

### DIFF
--- a/app/transitions/fix_future_dated_entries_transition.rb
+++ b/app/transitions/fix_future_dated_entries_transition.rb
@@ -1,0 +1,17 @@
+class FixFutureDatedEntriesTransition
+  def self.perform
+    new.perform
+  end
+
+  def perform
+    entries_with_dates_in_the_future.each do |entry|
+      entry.update_attribute(:date, entry.date - 1.year)
+    end
+  end
+
+  private
+
+  def entries_with_dates_in_the_future
+    Entry.where("date > ?", Date.today)
+  end
+end

--- a/spec/transitions/fix_future_dated_entries_transition_spec.rb
+++ b/spec/transitions/fix_future_dated_entries_transition_spec.rb
@@ -1,0 +1,35 @@
+describe FixFutureDatedEntriesTransition do
+  describe "#perform" do
+    context "for entries dated in the past" do
+      it "does nothing" do
+        last_year = 1.year.ago.to_date
+        yesterday = 1.day.ago.to_date
+        entry_from_last_year = create(:entry, date: last_year)
+        entry_from_yesterday = create(:entry, date: yesterday)
+
+        FixFutureDatedEntriesTransition.perform
+
+        entry_from_last_year.reload
+        entry_from_yesterday.reload
+        expect(entry_from_last_year.date).to eq(last_year)
+        expect(entry_from_yesterday.date).to eq(yesterday)
+      end
+    end
+
+    context "for entries dated in the future" do
+      it "fixes the date by moving them one year back" do
+        tomorrow = 1.day.from_now.to_date
+        next_week = 1.week.from_now.to_date
+        entry_from_tomorrow = create(:entry, date: tomorrow)
+        entry_from_next_week = create(:entry, date: next_week)
+
+        FixFutureDatedEntriesTransition.perform
+
+        entry_from_tomorrow.reload
+        entry_from_next_week.reload
+        expect(entry_from_tomorrow.date).to eq(tomorrow - 1.year)
+        expect(entry_from_next_week.date).to eq(next_week - 1.year)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Before we deployed #142, a bug existed where we could reply to an email from last year and it would be dated in the future. This happened because we always assumed the current year when dating entries. If an email prompt from Dec 31 2014 received a response on Jan 1 2015, then the entry would be dated Dec 31 2015.

This transition fixes any entries that were created when the bug existed. Any entry dated for the future will be moved one year into the past (the correct date). There are 36 entries in production that will be effected. The latest of these entries was created Jan 3 2015, just before the fix was deployed.

```ruby
> entries_in_the_future = Entry.where("date > ?", Date.today)

> entries_in_the_future.count
=> 36

> entries_in_the_future.map(&:created_at).last
=> Sat, 03 Jan 2015 00:00:59 UTC +00:00
```

After this is deployed, we can run the transition in the console with:

```ruby
> FixFutureDatedEntriesTransition.perform
```

cc @cstack who pointed out that he had entries with the wrong dates. Your entries will look correct once we run this transition.