### PR TITLE
Require cancellation reason

### DIFF
--- a/app/views/subscriptions/_close_account.html.erb
+++ b/app/views/subscriptions/_close_account.html.erb
@@ -38,15 +38,16 @@
       </p>
 
       <p>
-        If you can provide any feedback to help improve Trailmix for other
-        journalers, we would be very grateful.
+        Please also let us know why you're canceling. It really helps us
+        improve Trailmix.
       </p>
 
       <input type="text"
             class="form-control input-lg"
             id="reason"
             name="reason"
-            placeholder="Any feedback for us?">
+            placeholder="Why are you canceling? (required)"
+            required />
     </div>
     <div class="modal-footer">
       <button type="button"


### PR DESCRIPTION
Only 1/4 of canceling users specify a reason. This change makes the
reason required, which will hopefully provide us with more feedback.

![sample](https://cloud.githubusercontent.com/assets/46677/6306977/001aefa0-b906-11e4-8a68-60314ff5f36d.gif)


(Ignore the exception when I actually click "Close account." It's because I pulled the prod db locally and Stripe is complaining about the live/test key mismatch.)