### PR TITLE
Use https://www.trailmix.life in all mailers

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -87,7 +87,10 @@ Rails.application.configure do
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false
 
-  config.action_mailer.default_url_options = { host: 'trailmix.life' }
+  config.action_mailer.default_url_options = {
+    protocol: "https",
+    host: "www.trailmix.life"
+  }
 
   config.middleware.use(Rack::SslEnforcer)
 end


### PR DESCRIPTION
:eyes: @r00k 

Thanks @dainmiller for letting us know about this bug. 🌈

The password reset link we provide in emails currently does not work because we need to send folks to `www.trailmix.life` instead of `trailmix.life`.

This fixes PR that and also adds `https` to the url for the heck of it.