### PR TITLE
Add link to OhLife import page in FAQ

### DIFF
--- a/app/views/pages/faq.html.erb
+++ b/app/views/pages/faq.html.erb
@@ -40,7 +40,8 @@
 <h3>Can I import my OhLife entries?</h3>
 
 <p>
-  Yep! It takes two clicks and ten seconds.
+  Yep! It takes two clicks and ten seconds. Visit the
+  <%= link_to "import page", new_import_path %> to get things started.
 </p>
 
 <h3>Can I export my Trailmix entries?</h3>


### PR DESCRIPTION
:eyes: @r00k 

Folks are given the opportunity to import OhLife entries when they first sign up, but sometimes they either miss that opportunity or don't decide until later to import old entries. This adds a link to the import page to the FAQ so it's a bit easier to find.