### PR TITLE
Choose a PromptEntry at random rather than random-ish.

### DIFF
--- a/app/models/prompt_entry.rb
+++ b/app/models/prompt_entry.rb
@@ -1,38 +1,17 @@
 class PromptEntry
-  def initialize(entries, time_zone)
+  def initialize(entries)
     @entries = entries
-    @time_zone = time_zone
   end
 
-  def self.best(entries, time_zone)
-    new(entries, time_zone).best
+  def self.best(entries)
+    new(entries).best
   end
 
   def best
-    interesting || random
+    entries.random
   end
 
   private
 
-  attr_reader :entries, :time_zone
-
-  def interesting
-    entries.by_date.where(date: dates).last
-  end
-
-  def random
-    entries.random
-  end
-
-  def dates
-    durations.map { |duration| today - duration }
-  end
-
-  def durations
-    [1.year, 1.month, 1.week]
-  end
-
-  def today
-    Time.current.in_time_zone(time_zone).to_date
-  end
+  attr_reader :entries
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -30,7 +30,7 @@ class User < ActiveRecord::Base
   end
 
   def prompt_entry
-    PromptEntry.best(entries, time_zone)
+    PromptEntry.best(entries)
   end
 
   def prompt_delivery_hour

--- a/spec/models/prompt_entry_spec.rb
+++ b/spec/models/prompt_entry_spec.rb
@@ -1,60 +1,13 @@
 describe PromptEntry do
   describe "#best" do
-    context "when there's an entry from one year ago" do
-      it "returns that entry" do
-        Timecop.freeze(2014, 1, 2, 20) do # 8PM UTC
-          user = create(:user, time_zone: "Guam") # UTC+10
-          one_year_ago = Date.new(2013, 1, 3)
-          one_year_entry = create(:entry, user: user, date: one_year_ago)
-          create(:entry, user: user, date: 1.week.ago)
+    it "returns a random entry" do
+      user = create(:user)
+      random_entry = double(:entry)
+      allow(user.entries).to(receive(:random).and_return(random_entry))
 
-          best = PromptEntry.new(user.entries, user.time_zone).best
+      best = PromptEntry.new(user.entries).best
 
-          expect(best).to eq(one_year_entry)
-        end
-      end
-    end
-
-    context "when there's an entry from one month ago" do
-      it "returns that entry" do
-        Timecop.freeze(2014, 1, 2, 20) do # 8PM UTC
-          user = create(:user, time_zone: "Guam") # UTC+10
-          one_month_ago = Date.new(2013, 12, 3)
-          create(:entry, user: user, date: 1.week.ago)
-          one_month_entry = create(:entry, user: user, date: one_month_ago)
-
-          best = PromptEntry.new(user.entries, user.time_zone).best
-
-          expect(best).to eq(one_month_entry)
-        end
-      end
-    end
-
-    context "when there's an entry from one week ago" do
-      it "returns that entry" do
-        Timecop.freeze(2014, 1, 2, 20) do # 8PM UTC
-          user = create(:user, time_zone: "Guam") # UTC+10
-          one_week_ago = Date.new(2013, 12, 27)
-          create(:entry, user: user, date: 2.years.ago)
-          one_week_entry = create(:entry, user: user, date: one_week_ago)
-
-          best = PromptEntry.new(user.entries, user.time_zone).best
-
-          expect(best).to eq(one_week_entry)
-        end
-      end
-    end
-
-    context "when there are no interesting entries" do
-      it "returns a random entry" do
-        user = create(:user)
-        random_entry = double(:entry)
-        allow(user.entries).to(receive(:random).and_return(random_entry))
-
-        best = PromptEntry.new(user.entries, user.time_zone).best
-
-        expect(best).to eq(random_entry)
-      end
+      expect(best).to eq(random_entry)
     end
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe User, :type => :model do
     it "delegates to PromptEntry" do
       user = create(:user)
       allow(PromptEntry).to(
-        receive(:best).with(user.entries, user.time_zone).
+        receive(:best).with(user.entries).
         and_return("best entry"))
 
       entry = user.prompt_entry


### PR DESCRIPTION
As discussed in #154, our current system for choosing which entry to include
with the daily prompt penalizes consistent writers.

This commit makes our selection of previous entry truly random.

Fixes #154