### PR TITLE
Use "current year" and "last year" in tests

### DIFF
--- a/spec/models/email_processor_spec.rb
+++ b/spec/models/email_processor_spec.rb
@@ -94,8 +94,8 @@ describe EmailProcessor do
 
     context "when the entry is a response to a past day's email" do
       it "sets the entry date to the email's date" do
-        past_day = Date.new(2014, 1, 2)
-        Timecop.freeze(2014, 5, 10) do
+        past_day = Date.new(last_year, 1, 2)
+        Timecop.freeze(last_year, 5, 10) do
           user = create(:user)
           email = create(
             :griddler_email,
@@ -112,20 +112,28 @@ describe EmailProcessor do
 
     context "when the entry is a response to an email from last year" do
       it "sets the entry date to last year" do
-        last_year = Date.new(2014, 12, 31)
-        Timecop.freeze(2015, 1, 1) do
+        end_of_last_year = Date.new(last_year, 12, 31)
+        Timecop.freeze(current_year, 1, 1) do
           user = create(:user)
           email = create(
             :griddler_email,
             to: [{ token: user.reply_token }],
-            subject: "Re: #{PromptMailer::Subject.new(user, last_year)}"
+            subject: "Re: #{PromptMailer::Subject.new(user, end_of_last_year)}"
           )
 
           EmailProcessor.new(email).process
 
-          expect(user.newest_entry.date).to eq(last_year)
+          expect(user.newest_entry.date).to eq(end_of_last_year)
         end
       end
     end
+  end
+
+  def current_year
+    Date.today.year
+  end
+
+  def last_year
+    current_year - 1
   end
 end


### PR DESCRIPTION
:eyes: @r00k 

Trailmix supports responses to emails from at most one year ago. We have a couple tests failing right now because they are using dates from 2014 (more than a year ago). This updates the tests to use the current year and last year. 