### PR TITLE
Include the orginal entry date in prompt emails

### DIFF
--- a/app/mailers/prompt_mailer.rb
+++ b/app/mailers/prompt_mailer.rb
@@ -25,7 +25,7 @@ class PromptMailer < ActionMailer::Base
     private
 
     def date
-      I18n.l(@date, format: :for_prompt)
+      I18n.l(@date, format: :prompt_subject_line)
     end
   end
 end

--- a/app/views/prompt_mailer/prompt.html.erb
+++ b/app/views/prompt_mailer/prompt.html.erb
@@ -3,7 +3,7 @@
 <p>Simply reply to this email with your entry.</p>
 
 <% if @entry %>
-  <p>Remember this? <%= (distance_of_time_in_words(@date, @entry.date)).capitalize %> ago you wrote the following:</p>
+  <p>Remember this? On <%= I18n.l(@entry.date, format: :month_day_year) %> (<%= (distance_of_time_in_words(@date, @entry.date)) %> ago), you wrote the following:</p>
 
   <p>----------------------</p>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -5,7 +5,7 @@ en:
         "%m/%d/%Y"
       day_of_week:
         "%A"
-      for_prompt:
+      prompt_subject_line:
         "%A, %b %-d" # Thursday, Sept 17
       month_day_year:
         "%B %-d, %Y"

--- a/spec/mailers/prompt_mailer_spec.rb
+++ b/spec/mailers/prompt_mailer_spec.rb
@@ -53,6 +53,19 @@ describe PromptMailer do
         end
       end
 
+      it "describes when the user created their entry" do
+        Timecop.freeze(Date.new(2014, 1, 10)) do
+          user = create(:user)
+          entry = create(:entry, user: user, date: Date.new(2014, 1, 1))
+
+          mail = PromptMailer.prompt(user, entry)
+
+          expect(mail.body.encoded).to(
+            include("On January 1, 2014 (8 days ago)")
+          )
+        end
+      end
+
       it "formats the previous entry with html" do
         user = create(:user)
         entry = create(:entry, user: user, body: "Line 1\n\nLine 2")


### PR DESCRIPTION
We use `distance_of_time_in_words` for describing how long ago an entry
was created.

This works quite nicely for most values, but is a bit too coarse for
some time ranges (1 year and 3 months and 1 year and 9 months are both
described as "over 1 year").

This commit retains this approximation of time distance, but adds the
full entry date to the prompt. Users can consult the exact date if they
want additional precision.

Since the prompt now has multiple formatted dates, this commit also
changes the `:for_prompt` date description to `:prompt_subject_line` to
avoid confusion.