### PR TITLE
Editable entries

### DIFF
--- a/app/controllers/cancellations_controller.rb
+++ b/app/controllers/cancellations_controller.rb
@@ -7,7 +7,7 @@ class CancellationsController < ApplicationController
     flash[:notice] = "Your account has been removed and " +
       "your subscription has been canceled."
 
-    redirect_to entries_path
+    redirect_to new_registration_path
   end
 
   private

--- a/app/controllers/entries_controller.rb
+++ b/app/controllers/entries_controller.rb
@@ -6,4 +6,21 @@ class EntriesController < ApplicationController
       redirect_to new_registration_path
     end
   end
+
+  def edit
+    @entry = Entry.find(params[:id])
+  end
+
+  def update
+    entry = Entry.find(params[:id])
+    entry.update_attributes!(entry_params)
+
+    redirect_to entries_path
+  end
+
+  private
+
+  def entry_params
+    params.require(:entry).permit(:body)
+  end
 end

--- a/app/controllers/entries_controller.rb
+++ b/app/controllers/entries_controller.rb
@@ -6,17 +6,20 @@ class EntriesController < ApplicationController
   end
 
   def edit
-    @entry = Entry.find(params[:id])
+    @entry = entry
   end
 
   def update
-    entry = Entry.find(params[:id])
     entry.update_attributes!(entry_params)
 
     redirect_to entries_path
   end
 
   private
+
+  def entry
+    current_user.entries.find_by!(id: params[:id])
+  end
 
   def entry_params
     params.require(:entry).permit(:body)

--- a/app/controllers/entries_controller.rb
+++ b/app/controllers/entries_controller.rb
@@ -1,10 +1,8 @@
 class EntriesController < ApplicationController
+  before_action :authenticate_user!
+
   def index
-    if user_signed_in?
-      @entries = current_user.entries.by_date.page(params[:page])
-    else
-      redirect_to new_registration_path
-    end
+    @entries = current_user.entries.by_date.page(params[:page])
   end
 
   def edit

--- a/app/models/entry.rb
+++ b/app/models/entry.rb
@@ -19,8 +19,4 @@ class Entry < ActiveRecord::Base
   def for_today?
     date == Time.zone.now.in_time_zone(user.time_zone).to_date
   end
-
-  def body=(new_body)
-    super([body, new_body].compact.join("\n\n"))
-  end
 end

--- a/app/views/entries/_date.html.erb
+++ b/app/views/entries/_date.html.erb
@@ -1,0 +1,10 @@
+<h1>
+  <% if today %>
+    Today
+  <% else %>
+    <%= l(date, format: :day_of_week) %>
+  <% end %>
+</h1>
+<p class="lead">
+  <%= l(date, format: :month_day_year) %>
+</p>

--- a/app/views/entries/_entry.html.erb
+++ b/app/views/entries/_entry.html.erb
@@ -13,6 +13,8 @@
 
 <%= paginate @entries %>
 
+<%= link_to "Edit", edit_entry_path(entry) %>
+
 <%= simple_format(entry.body) %>
 
 <% if entry.photo.url %>

--- a/app/views/entries/_entry.html.erb
+++ b/app/views/entries/_entry.html.erb
@@ -5,11 +5,11 @@
   %>
 <% end %>
 
-<%= paginate @entries %>
-
 <p>
-  <%= link_to "Edit", edit_entry_path(entry) %>
+  <%= link_to "Edit this entry", edit_entry_path(entry) %>
 </p>
+
+<%= paginate @entries %>
 
 <%= simple_format(entry.body) %>
 

--- a/app/views/entries/_entry.html.erb
+++ b/app/views/entries/_entry.html.erb
@@ -1,19 +1,15 @@
 <% content_for :header do %>
-  <h1>
-    <% if entry.for_today? %>
-      Today
-    <% else %>
-      <%= l(entry.date, format: :day_of_week) %>
-    <% end %>
-  </h1>
-  <p class="lead">
-    <%= l(entry.date, format: :month_day_year) %>
-  </p>
+  <%= render partial: "date",
+    object: entry.date,
+    locals: { today: entry.for_today? }
+  %>
 <% end %>
 
 <%= paginate @entries %>
 
-<%= link_to "Edit", edit_entry_path(entry) %>
+<p>
+  <%= link_to "Edit", edit_entry_path(entry) %>
+</p>
 
 <%= simple_format(entry.body) %>
 

--- a/app/views/entries/edit.html.erb
+++ b/app/views/entries/edit.html.erb
@@ -1,7 +1,19 @@
-<%= form_for @entry do |form| %>
-  <div class="form-group">
-    <%= form.text_area :body %>
-  </div>
-
-  <%= form.submit "Save Entry", class: "btn btn-default btn-lg" %>
+<% content_for :header do %>
+  <%= render partial: "date",
+    object: @entry.date,
+    locals: { today: @entry.for_today? }
+  %>
 <% end %>
+
+<p>
+  <%= form_for @entry do |f| %>
+    <div class="form-group">
+      <%= f.text_area :body,
+        class: "form-control input-lg",
+        autofocus: true
+      %>
+    </div>
+
+    <%= f.submit "Save Entry", class: "btn btn-default btn-lg" %>
+  <% end %>
+</p>

--- a/app/views/entries/edit.html.erb
+++ b/app/views/entries/edit.html.erb
@@ -1,0 +1,7 @@
+<%= form_for @entry do |form| %>
+  <div class="form-group">
+    <%= form.text_area :body %>
+  </div>
+
+  <%= form.submit "Save Entry", class: "btn btn-default btn-lg" %>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,7 +14,7 @@ Rails.application.routes.draw do
 
   resources :cancellations, only: [:create]
   resource :credit_card, only: [:edit, :update]
-  resources :entries, only: [:index]
+  resources :entries, only: [:index, :edit, :update]
   resource :export, only: [:new]
   resources :imports, only: [:new, :create]
   resource :settings, only: [:edit, :update]

--- a/spec/features/user_edits_entry_spec.rb
+++ b/spec/features/user_edits_entry_spec.rb
@@ -5,7 +5,7 @@ feature "User edits entry" do
 
     login_as(user)
     visit entries_path
-    click_link "Edit"
+    click_link "Edit this entry"
     fill_in :entry_body, with: "New body"
     click_button "Save Entry"
 

--- a/spec/features/user_edits_entry_spec.rb
+++ b/spec/features/user_edits_entry_spec.rb
@@ -12,4 +12,15 @@ feature "User edits entry" do
     expect(page).to_not have_content("Original body")
     expect(page).to have_content("New body")
   end
+
+  scenario "and the entry belongs to another user" do
+    user = create(:user)
+    another_user = create(:user)
+    another_users_entry = create(:entry, user: another_user)
+
+    login_as(user)
+    visit edit_entry_path(another_users_entry)
+
+    expect(page.status_code).to eq(404)
+  end
 end

--- a/spec/features/user_edits_entry_spec.rb
+++ b/spec/features/user_edits_entry_spec.rb
@@ -1,0 +1,15 @@
+feature "User edits entry" do
+  scenario "and the entry body is updated" do
+    user = create(:user)
+    create(:entry, user: user, body: "Original body")
+
+    login_as(user)
+    visit entries_path
+    click_link "Edit"
+    fill_in :entry_body, with: "New body"
+    click_button "Save Entry"
+
+    expect(page).to_not have_content("Original body")
+    expect(page).to have_content("New body")
+  end
+end

--- a/spec/features/user_signs_out_spec.rb
+++ b/spec/features/user_signs_out_spec.rb
@@ -8,6 +8,6 @@ feature "User signs out" do
 
     click_button "Sign out"
 
-    expect(current_path).to eq new_registration_path
+    expect(current_path).to eq new_user_session_path
   end
 end

--- a/spec/features/user_views_entries_spec.rb
+++ b/spec/features/user_views_entries_spec.rb
@@ -39,6 +39,6 @@ feature "User views entries" do
   scenario "when signed out" do
     visit entries_path
 
-    expect(current_path).to eq new_registration_path
+    expect(current_path).to eq new_user_session_path
   end
 end

--- a/spec/models/entry_spec.rb
+++ b/spec/models/entry_spec.rb
@@ -58,25 +58,4 @@ RSpec.describe Entry, :type => :model do
       end
     end
   end
-
-  context "when the entry already has a body" do
-    it "amends that body" do
-      today = Date.current
-      entry = create(:entry, date: today, body: "First line")
-
-      entry.body = "Second line"
-
-      expect(entry.body).to eq("First line\n\nSecond line")
-    end
-  end
-
-  context "when the entry does not have a body already" do
-    it "sets the body as usual" do
-      entry = Entry.new
-
-      entry.body = "My body"
-
-      expect(entry.body).to eq("My body")
-    end
-  end
 end


### PR DESCRIPTION
:eyes: @r00k 

This allows folks to edit their entries on trailmix.life and removes the ability to amend entries via email.

It would be cool to followup with another PR to delete an attached photo.

![edit-entry](https://cloud.githubusercontent.com/assets/65323/12568865/0888a882-c38f-11e5-8e04-5b08429774cc.gif)
