### PR TITLE
Update rails-html-sanitizer, fixes CVE-2018-3741

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -90,7 +90,7 @@ GEM
     connection_pool (2.0.0)
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
-    crass (1.0.3)
+    crass (1.0.4)
     database_cleaner (1.3.0)
     debug_inspector (0.0.2)
     debugger-linecache (1.2.0)
@@ -321,7 +321,7 @@ GEM
     kgio (2.9.2)
     launchy (2.4.2)
       addressable (~> 2.3)
-    loofah (2.2.1)
+    loofah (2.2.2)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
     mail (2.7.0)
@@ -373,8 +373,8 @@ GEM
       activesupport (>= 4.2.0, < 5.0)
       nokogiri (~> 1.6)
       rails-deprecated_sanitizer (>= 1.0.1)
-    rails-html-sanitizer (1.0.3)
-      loofah (~> 2.0)
+    rails-html-sanitizer (1.0.4)
+      loofah (~> 2.2, >= 2.2.2)
     rails_12factor (0.0.3)
       rails_serve_static_assets
       rails_stdout_logging


### PR DESCRIPTION
cc @r00k @ehmorris for review.

Fixes [CVE-2018-3741](https://groups.google.com/forum/#!msg/rubyonrails-security/tP7W3kLc5u4/uDy2Br7xBgAJ):

> Possible XSS vulnerability in rails-html-sanitizer
> 
> There is a possible XSS vulnerability in rails-html-sanitizer. This
> vulnerability has been assigned the CVE identifier CVE-2018-3741.
> 
> Versions Affected:  1.0.3 or older.
> Not affected:       None.
> Fixed Versions:     1.0.4
> 
> Impact
> ------
> There is a possible XSS vulnerability in rails-html-sanitizer.  The gem allows non-whitelisted attributes to be present in sanitized output when input with specially-crafted HTML fragments, and these attributes can lead to an XSS attack on target applications.
