### PR TITLE
Upgrade jquery-rails

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -297,8 +297,8 @@ GEM
       terminal-table
     inflecto (0.0.2)
     ipaddress (0.8.3)
-    jquery-rails (4.0.4)
-      rails-dom-testing (~> 1.0)
+    jquery-rails (4.6.0)
+      rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
     json (1.8.6)


### PR DESCRIPTION
The current version of jquery-rails blocks an upgrade to Rails 5.0 because it depends on rails-dom-testing ~> 1.0 and Rails 5.0 depends on rails-dom-testing ~> 2.0. This PR upgrades jquery-rails to the latest version to unblock the Rails upgrade.

We must continue using jQuery to support Bootstrap. I confirmed in development that JavaScript and CSS continue to work correctly.