### PR TITLE
Upgrade to Sidekiq 4

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -31,7 +31,7 @@ gem "rails", "~> 5.0.7"
 gem "recipient_interceptor"
 gem "redis"
 gem "sass-rails", "~> 5.0.7"
-gem "sidekiq"
+gem "sidekiq", "~> 4.2.10"
 gem "sprockets", ">= 2.12.5"
 gem "simple_form", "~> 5.0.3"
 gem "sinatra", "~> 2.0.8", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -75,13 +75,11 @@ GEM
       activesupport (>= 3.2.0)
       json (>= 1.7)
       mime-types (>= 1.16)
-    celluloid (0.15.2)
-      timers (~> 1.1.0)
     chartkick (3.4.0)
     childprocess (3.0.0)
     coderay (1.1.3)
     concurrent-ruby (1.3.5)
-    connection_pool (2.0.0)
+    connection_pool (2.5.0)
     crack (1.0.0)
       bigdecimal
       rexml
@@ -423,9 +421,7 @@ GEM
       trollop (~> 2.1)
     recipient_interceptor (0.1.2)
       mail
-    redis (3.1.0)
-    redis-namespace (1.5.1)
-      redis (~> 3.0, >= 3.0.4)
+    redis (3.3.5)
     regexp_parser (2.9.2)
     responders (2.4.1)
       actionpack (>= 4.2.0, < 6.0)
@@ -470,12 +466,11 @@ GEM
       rubyzip (>= 1.2.2)
     shoulda-matchers (2.7.0)
       activesupport (>= 3.0.0)
-    sidekiq (3.2.5)
-      celluloid (= 0.15.2)
-      connection_pool (>= 2.0.0)
-      json
-      redis (>= 3.0.6)
-      redis-namespace (>= 1.3.1)
+    sidekiq (4.2.10)
+      concurrent-ruby (~> 1.0)
+      connection_pool (~> 2.2, >= 2.2.0)
+      rack-protection (>= 1.5.0)
+      redis (~> 3.2, >= 3.2.1)
     simple_form (5.0.3)
       actionpack (>= 5.0)
       activemodel (>= 5.0)
@@ -513,7 +508,6 @@ GEM
     tilt (2.6.0)
     timecop (0.7.1)
     timeout (0.4.3)
-    timers (1.1.0)
     tins (1.3.3)
     title (0.0.5)
       i18n
@@ -599,7 +593,7 @@ DEPENDENCIES
   sass-rails (~> 5.0.7)
   selenium-webdriver
   shoulda-matchers
-  sidekiq
+  sidekiq (~> 4.2.10)
   simple_form (~> 5.0.3)
   sinatra (~> 2.0.8)
   skylight


### PR DESCRIPTION
In order to get Trailmix working properly in production again, we need to [upgrade to redis gem >= 4.0.2 in order to connect to Heroku Key-Value Store](https://devcenter.heroku.com/articles/connecting-heroku-redis#connecting-in-ruby). That requires Sidekiq 6.0, which in turn requires Rails >= 5.0.

This PR upgrades to Sidekiq 4.2.10.