### PR TITLE
Upgrade to Sidekiq 5

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -31,7 +31,7 @@ gem "rails", "~> 5.0.7"
 gem "recipient_interceptor"
 gem "redis"
 gem "sass-rails", "~> 5.0.7"
-gem "sidekiq", "~> 4.2.10"
+gem "sidekiq", "~> 5.2.10"
 gem "sprockets", ">= 2.12.5"
 gem "simple_form", "~> 5.0.3"
 gem "sinatra", "~> 2.0.8", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -421,7 +421,7 @@ GEM
       trollop (~> 2.1)
     recipient_interceptor (0.1.2)
       mail
-    redis (3.3.5)
+    redis (4.5.1)
     regexp_parser (2.9.2)
     responders (2.4.1)
       actionpack (>= 4.2.0, < 6.0)
@@ -466,11 +466,11 @@ GEM
       rubyzip (>= 1.2.2)
     shoulda-matchers (2.7.0)
       activesupport (>= 3.0.0)
-    sidekiq (4.2.10)
-      concurrent-ruby (~> 1.0)
-      connection_pool (~> 2.2, >= 2.2.0)
+    sidekiq (5.2.10)
+      connection_pool (~> 2.2, >= 2.2.2)
+      rack (~> 2.0)
       rack-protection (>= 1.5.0)
-      redis (~> 3.2, >= 3.2.1)
+      redis (~> 4.5, < 4.6.0)
     simple_form (5.0.3)
       actionpack (>= 5.0)
       activemodel (>= 5.0)
@@ -593,7 +593,7 @@ DEPENDENCIES
   sass-rails (~> 5.0.7)
   selenium-webdriver
   shoulda-matchers
-  sidekiq (~> 4.2.10)
+  sidekiq (~> 5.2.10)
   simple_form (~> 5.0.3)
   sinatra (~> 2.0.8)
   skylight


### PR DESCRIPTION
In order to get Trailmix working properly in production again, we need to [upgrade to redis gem >= 4.0.2 in order to connect to Heroku Key-Value Store](https://devcenter.heroku.com/articles/connecting-heroku-redis#connecting-in-ruby). That requires Sidekiq 6.0, which in turn requires Rails >= 5.0.

This PR upgrades to Sidekiq 5.2.10.