### PR TITLE
Fix Redis connection

### DIFF
--- a/config/initializers/redis.rb
+++ b/config/initializers/redis.rb
@@ -1,0 +1,2 @@
+# https://devcenter.heroku.com/articles/connecting-heroku-redis#connecting-in-ruby
+$redis = Redis.new(url: ENV["REDIS_URL"], ssl_params: { verify_mode: OpenSSL::SSL::VERIFY_NONE })

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -7,3 +7,18 @@ Sidekiq::Web.use(Rack::Auth::Basic) do |user, password|
     ENV.fetch("SIDEKIQ_WEB_PASSWORD")
   ]
 end
+
+# https://devcenter.heroku.com/articles/connecting-heroku-redis#connecting-in-ruby
+Sidekiq.configure_server do |config|
+  config.redis = {
+    url: ENV["REDIS_URL"],
+    ssl_params: { verify_mode: OpenSSL::SSL::VERIFY_NONE }
+  }
+end
+
+Sidekiq.configure_client do |config|
+  config.redis = {
+      url: ENV["REDIS_URL"],
+      ssl_params: { verify_mode: OpenSSL::SSL::VERIFY_NONE }
+  }
+end


### PR DESCRIPTION
Heroku made a change that requires TLS connections to Heroku Key-Value Store. This PR follows [the Heroku documentation](https://devcenter.heroku.com/articles/connecting-heroku-redis#connecting-in-ruby) for connecting in Ruby.