### PR TITLE
Remove shoulda-matchers gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -63,7 +63,6 @@ group :test do
   gem "formulaic"
   gem "stripe-ruby-mock", "~> 2.4.0"
   gem "launchy"
-  gem "shoulda-matchers", require: false
   gem "timecop"
   gem "webmock"
   gem "puma", "~> 6.4.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -464,8 +464,6 @@ GEM
     selenium-webdriver (3.142.7)
       childprocess (>= 0.5, < 4.0)
       rubyzip (>= 1.2.2)
-    shoulda-matchers (2.7.0)
-      activesupport (>= 3.0.0)
     sidekiq (5.2.10)
       connection_pool (~> 2.2, >= 2.2.2)
       rack (~> 2.0)
@@ -592,7 +590,6 @@ DEPENDENCIES
   rspec-rails (~> 3.7.0)
   sass-rails (~> 5.0.7)
   selenium-webdriver
-  shoulda-matchers
   sidekiq (~> 5.2.10)
   simple_form (~> 5.0.3)
   sinatra (~> 2.0.8)

--- a/spec/models/entry_spec.rb
+++ b/spec/models/entry_spec.rb
@@ -1,8 +1,6 @@
 require 'rails_helper'
 
 RSpec.describe Entry, :type => :model do
-  it { should belong_to(:import) }
-
   describe ".by_date" do
     it "sorts entries, by date, with the newest first" do
       user = create(:user)

--- a/spec/models/import_spec.rb
+++ b/spec/models/import_spec.rb
@@ -1,6 +1,0 @@
-require 'rails_helper'
-
-describe Import do
-  it { should have_many(:entries) }
-  it { should belong_to(:user) }
-end

--- a/spec/models/subscription_spec.rb
+++ b/spec/models/subscription_spec.rb
@@ -1,3 +1,0 @@
-describe Subscription do
-  it { should belong_to(:user) }
-end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,8 +1,4 @@
 RSpec.describe User, :type => :model do
-  it { should have_many(:entries).dependent(:destroy) }
-  it { should have_many(:imports).dependent(:destroy) }
-  it { should have_one(:subscription).dependent(:destroy) }
-
   describe ".promptable" do
     it "returns promptable users for the current hour" do
       Timecop.freeze(Time.utc(2014, 1, 1, 11)) do # 11AM UTC

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,7 +3,6 @@ ENV["RAILS_ENV"] = "test"
 require File.expand_path("../../config/environment", __FILE__)
 
 require "rspec/rails"
-require "shoulda/matchers"
 require "webmock/rspec"
 require "stripe_mock"
 


### PR DESCRIPTION
Our test output has deprecation warnings like the ones mentioned in https://github.com/thoughtbot/shoulda-matchers/issues/1166. Fixing these would require upgrading the shoulda-matchers gem by multiple major versions. I opted to delete the assertions that used shoulda-matchers instead: these are testing implementation details that should be caught by assertions about application behavior instead.