### PR TITLE
Upgrade Airbrake gem

### DIFF
--- a/.sample.env
+++ b/.sample.env
@@ -1,6 +1,5 @@
 # http://ddollar.github.com/foreman/
 ADMIN_EMAILS=ben@trailmix.life,chris@trailmix.life
-AIRBRAKE_API_KEY=boo123
 AWS_ACCESS_KEY_ID=abc123
 AWS_SECRET_ACCESS_KEY=def456
 DEVISE_SECRET_KEY=foo

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -41,9 +41,10 @@ GEM
       tzinfo (~> 1.1)
     addressable (2.8.7)
       public_suffix (>= 2.0.2, < 7.0)
-    airbrake (4.1.0)
-      builder
-      multi_json
+    airbrake (13.0.5)
+      airbrake-ruby (~> 6.0)
+    airbrake-ruby (6.2.2)
+      rbtree3 (~> 0.6)
     arel (7.1.4)
     autoprefixer-rails (10.4.19.0)
       execjs (~> 2)
@@ -414,6 +415,7 @@ GEM
       thor (>= 0.18.1, < 2.0)
     raindrops (0.13.0)
     rake (13.2.1)
+    rbtree3 (0.7.1)
     rbvmomi (1.11.7)
       builder (~> 3.0)
       json (>= 1.8)

--- a/config/initializers/airbrake.rb
+++ b/config/initializers/airbrake.rb
@@ -1,3 +1,80 @@
-Airbrake.configure do |config|
-  config.api_key = ENV.fetch("AIRBRAKE_API_KEY")
+# frozen_string_literal: true
+
+# Airbrake is an online tool that provides robust exception tracking in your
+# Rails applications. In doing so, it allows you to easily review errors, tie an
+# error to an individual piece of code, and trace the cause back to recent
+# changes. Airbrake enables for easy categorization, searching, and
+# prioritization of exceptions so that when errors occur, your team can quickly
+# determine the root cause.
+#
+# Configuration details:
+# https://github.com/airbrake/airbrake-ruby#configuration
+if (project_id = ENV['AIRBRAKE_PROJECT_ID']) &&
+   project_key = (ENV['AIRBRAKE_PROJECT_KEY'] || ENV['AIRBRAKE_API_KEY'])
+  Airbrake.configure do |c|
+    # You must set both project_id & project_key. To find your project_id and
+    # project_key navigate to your project's General Settings and copy the
+    # values from the right sidebar.
+    # https://github.com/airbrake/airbrake-ruby#project_id--project_key
+    c.project_id = project_id
+    c.project_key = project_key
+
+    # Configures the root directory of your project. Expects a String or a
+    # Pathname, which represents the path to your project. Providing this option
+    # helps us to filter out repetitive data from backtrace frames and link to
+    # GitHub files from our dashboard.
+    # https://github.com/airbrake/airbrake-ruby#root_directory
+    c.root_directory = Rails.root
+
+    # By default, Airbrake Ruby outputs to STDOUT. In Rails apps it makes sense
+    # to use the Rails' logger.
+    # https://github.com/airbrake/airbrake-ruby#logger
+    c.logger = Airbrake::Rails.logger
+
+    # Configures the environment the application is running in. Helps the
+    # Airbrake dashboard to distinguish between exceptions occurring in
+    # different environments.
+    # NOTE: This option must be set in order to make the 'ignore_environments'
+    # option work.
+    # https://github.com/airbrake/airbrake-ruby#environment
+    c.environment = Rails.env
+
+    # Setting this option allows Airbrake to filter exceptions occurring in
+    # unwanted environments such as :test.  NOTE: This option *does not* work if
+    # you don't set the 'environment' option.
+    # https://github.com/airbrake/airbrake-ruby#ignore_environments
+    c.ignore_environments = %w[test]
+
+    # A list of parameters that should be filtered out of what is sent to
+    # Airbrake. By default, all "password" attributes will have their contents
+    # replaced.
+    # https://github.com/airbrake/airbrake-ruby#blocklist_keys
+    c.blocklist_keys = [/password/i, /authorization/i]
+
+    # Alternatively, you can integrate with Rails' filter_parameters.
+    # Read more: https://goo.gl/gqQ1xS
+    # c.blocklist_keys = Rails.application.config.filter_parameters
+  end
+
+  # A filter that collects request body information. Enable it if you are sure you
+  # don't send sensitive information to Airbrake in your body (such as passwords).
+  # https://github.com/airbrake/airbrake#requestbodyfilter
+  # Airbrake.add_filter(Airbrake::Rack::RequestBodyFilter.new)
+
+  # Attaches thread & fiber local variables along with general thread information.
+  # Airbrake.add_filter(Airbrake::Filters::ThreadFilter.new)
+
+  # Attaches loaded dependencies to the notice object
+  # (under context/versions/dependencies).
+  # Airbrake.add_filter(Airbrake::Filters::DependencyFilter.new)
+
+  # If you want to convert your log messages to Airbrake errors, we offer an
+  # integration with the Logger class from stdlib.
+  # https://github.com/airbrake/airbrake#logger
+  # Rails.logger = Airbrake::AirbrakeLogger.new(Rails.logger)
+else
+  Rails.logger.warn(
+    "#{__FILE__}: Airbrake project id or project key is not set. " \
+    "Skipping Airbrake configuration"
+  )
 end


### PR DESCRIPTION
The existing version of the Airbrake gem raised deprecation warnings on Rails 5. This PR upgrades the Airbrake gem following [these instructions](https://docs.airbrake.io/docs/platforms/ruby/#upgrading-from-deprecated-versions).

### Before deploy
- [ ] Add `AIRBRAKE_PROJECT_ID` and `AIRBRAKE_PROJECT_KEY` to production environment variables

### After deploy
- [ ] Remove `AIRBRAKE_API_KEY` from production environment variables