### PR TITLE
Replace calls to deprecated before_filter

### DIFF
--- a/app/controllers/admin_dashboard_controller.rb
+++ b/app/controllers/admin_dashboard_controller.rb
@@ -1,5 +1,5 @@
 class AdminDashboardController < ApplicationController
-  before_filter :authenticate_user!, :restrict_to_admins
+  before_action :authenticate_user!, :restrict_to_admins
 
   def show
     @dashboard = AdminDashboard.new

--- a/app/controllers/credit_cards_controller.rb
+++ b/app/controllers/credit_cards_controller.rb
@@ -1,5 +1,5 @@
 class CreditCardsController < ApplicationController
-  before_filter :authenticate_user!
+  before_action :authenticate_user!
 
   layout "skinny"
 

--- a/app/controllers/exports_controller.rb
+++ b/app/controllers/exports_controller.rb
@@ -1,5 +1,5 @@
 class ExportsController < ApplicationController
-  before_filter :authenticate_user!
+  before_action :authenticate_user!
 
   def new
     export = Export.new(current_user)

--- a/app/controllers/imports_controller.rb
+++ b/app/controllers/imports_controller.rb
@@ -1,5 +1,5 @@
 class ImportsController < ApplicationController
-  before_filter :authenticate_user!
+  before_action :authenticate_user!
 
   def new
     @import = Import.new

--- a/app/controllers/searches_controller.rb
+++ b/app/controllers/searches_controller.rb
@@ -1,5 +1,5 @@
 class SearchesController < ApplicationController
-  before_filter :authenticate_user!
+  before_action :authenticate_user!
 
   def show
     @search = Search.new(search_params)

--- a/app/controllers/settings_controller.rb
+++ b/app/controllers/settings_controller.rb
@@ -1,7 +1,7 @@
 class SettingsController < ApplicationController
   layout "skinny"
 
-  before_filter :authenticate_user!
+  before_action :authenticate_user!
 
   def edit
   end


### PR DESCRIPTION
`before_filter` is deprecated and will be removed in Rails 5.1. This PR replaces calls to `before_filter` with `before_action`.