### PR TITLE
Patch JSON gem to address deprecation warning

### DIFF
--- a/config/initializers/json.rb
+++ b/config/initializers/json.rb
@@ -1,0 +1,10 @@
+# Addresses a deprecation warning with json 1.8.6 and Ruby 2.7
+# https://github.com/ruby/json/issues/399#issuecomment-734863279
+
+module JSON
+  module_function
+
+  def parse(source, opts = {})
+    Parser.new(source, **opts).parse
+  end
+end


### PR DESCRIPTION
This patch addresses [a deprecation warning with json 1.8.6 and Ruby 2.7](https://github.com/ruby/json/issues/399#issuecomment-734863279). We can remove it later when we're on more recent versions.