### PR TITLE
Upgrade bigdecimal gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ ruby "2.7.4"
 
 gem "airbrake"
 gem "autoprefixer-rails"
-gem "bigdecimal", "~> 1.4.0"
+gem "bigdecimal", "~> 3.1.9"
 gem "binding_of_caller"
 gem "bourbon", "~> 3.2.1"
 gem "carrierwave"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -55,7 +55,7 @@ GEM
       coderay (>= 1.0.0)
       erubi (>= 1.0.0)
       rack (>= 0.9.0)
-    bigdecimal (1.4.4)
+    bigdecimal (3.1.9)
     binding_of_caller (1.0.1)
       debug_inspector (>= 1.2.0)
     bourbon (3.2.3)
@@ -552,7 +552,7 @@ DEPENDENCIES
   autoprefixer-rails
   awesome_print
   better_errors
-  bigdecimal (~> 1.4.0)
+  bigdecimal (~> 3.1.9)
   binding_of_caller
   bourbon (~> 3.2.1)
   carrierwave


### PR DESCRIPTION
The current, old version of the bigdecimal gem blocks an upgrade to Ruby 3. This PR upgrades bigdecimal to the latest version.