### PR TITLE
Reintroduce require statement to production.rb

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -1,3 +1,4 @@
+require Rails.root.join("config/smtp")
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 


### PR DESCRIPTION
I accidentally removed this in https://github.com/codecation/trailmix/pull/224. This PR unblocks production deploys.