### PR TITLE
Upgrade FactoryGirl to FactoryBot

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -55,7 +55,7 @@ end
 group :development, :test do
   gem "awesome_print"
   gem "dotenv-rails"
-  gem "factory_girl_rails"
+  gem "factory_bot_rails"
   gem "pry-rails"
   gem "rspec-activemodel-mocks"
   gem "rspec-rails", "~> 4.1.2"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -134,11 +134,11 @@ GEM
     erubi (1.13.1)
     excon (0.72.0)
     execjs (2.10.0)
-    factory_girl (4.4.0)
-      activesupport (>= 3.0.0)
-    factory_girl_rails (4.4.1)
-      factory_girl (~> 4.4.0)
-      railties (>= 3.0.0)
+    factory_bot (6.5.0)
+      activesupport (>= 5.0.0)
+    factory_bot_rails (6.4.4)
+      factory_bot (~> 6.5)
+      railties (>= 5.0.0)
     ffi (1.17.1)
     fission (0.5.0)
       CFPropertyList (~> 2.2)
@@ -613,7 +613,7 @@ DEPENDENCIES
   dotenv-rails
   email_reply_parser
   email_validator
-  factory_girl_rails
+  factory_bot_rails
   flutie
   fog
   formulaic

--- a/lib/tasks/development_seeds.rake
+++ b/lib/tasks/development_seeds.rake
@@ -1,10 +1,10 @@
 if Rails.env.development?
-  require "factory_girl"
+  require "factory_bot"
 
   namespace :dev do
     desc "Seed data for development environment"
     task prime: "db:setup" do
-      include FactoryGirl::Syntax::Methods
+      include FactoryBot::Syntax::Methods
 
       # create(:user, email: "user@example.com", password: "password")
     end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -1,16 +1,16 @@
-FactoryGirl.define do
+FactoryBot.define do
   sequence(:email) { |n| "user-#{n}@example.com" }
   sequence(:stripe_customer_id) { |n| "cus_#{n}" }
 
   factory :user do
     email
-    password 'abc123'
+    password { 'abc123' }
   end
 
   factory :entry do
     user
-    date Time.zone.now
-    body 'Entry body'
+    date { Time.zone.now }
+    body { 'Entry body' }
 
     trait :with_photo do
       photo do
@@ -31,15 +31,15 @@ FactoryGirl.define do
   end
 
   factory :griddler_email, class: OpenStruct do
-    to [{
+    to { [{
       full: "to_user@example.com",
       email: "to_user@example.com",
       token: "to_user",
       host: "example.com",
       name: nil
-    }]
-    from ({ email: "from_user@example.com" })
-    subject "Hello Trailmix"
-    body "Today was great"
+    }] }
+    from { ({ email: "from_user@example.com" }) }
+    subject { "Hello Trailmix" }
+    body { "Today was great" }
   end
 end

--- a/spec/support/factory_bot.rb
+++ b/spec/support/factory_bot.rb
@@ -1,0 +1,3 @@
+RSpec.configure do |config|
+  config.include FactoryBot::Syntax::Methods
+end

--- a/spec/support/factory_girl.rb
+++ b/spec/support/factory_girl.rb
@@ -1,3 +1,0 @@
-RSpec.configure do |config|
-  config.include FactoryGirl::Syntax::Methods
-end


### PR DESCRIPTION
FactoryGirl has been deprecated and replaced with FactoryBot. We must migrate to FactoryBot before we can upgrade to Ruby 3.2. This PR performs that migration following [these upgrade instructions](https://github.com/thoughtbot/factory_bot/blob/v4.9.0/UPGRADE_FROM_FACTORY_GIRL.md).