### PR TITLE
Remove Skylight gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -75,7 +75,3 @@ group :staging, :production do
   gem "rails_12factor", "~> 0.0.3"
   gem "rails_serve_static_assets", "~> 0.0.4"
 end
-
-group :production do
-  gem "skylight"
-end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -545,8 +545,6 @@ GEM
       rack (~> 2.0)
       rack-protection (= 2.0.8.1)
       tilt (~> 2.0)
-    skylight (0.3.21)
-      activesupport (>= 3.0.0)
     spring (1.1.3)
     spring-commands-rspec (1.0.2)
       spring (>= 0.9.1)
@@ -673,7 +671,6 @@ DEPENDENCIES
   sidekiq (~> 5.2.10)
   simple_form (~> 5.0.3)
   sinatra (~> 2.0.8)
-  skylight
   spring
   spring-commands-rspec
   sprockets (>= 2.12.5)


### PR DESCRIPTION
The current version of the Skylight gem throws an exception when deploying the Ruby 3.2 upgrade to production. This PR removes it. If and when we'd like to reintroduce it, we can follow [these instructions](https://www.skylight.io/support/getting-started) to install the latest version.