### PR TITLE
Run Uglifier in harmony mode to support ES6 syntax

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -566,9 +566,8 @@ GEM
     trollop (2.1.2)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
-    uglifier (2.5.3)
-      execjs (>= 0.3.0)
-      json (>= 1.8.0)
+    uglifier (4.2.1)
+      execjs (>= 0.3.0, < 3)
     unf (0.1.4)
       unf_ext
     unf_ext (0.0.7.6)

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -26,7 +26,7 @@ Rails.application.configure do
   config.public_file_server.enabled = ENV["RAILS_SERVE_STATIC_FILES"].present?
 
   # Compress JavaScripts and CSS.
-  config.assets.js_compressor = :uglifier
+  config.assets.js_compressor = Uglifier.new(harmony: true)
   # config.assets.css_compressor = :sass
 
   # Do not fallback to assets pipeline if a precompiled asset is missed.


### PR DESCRIPTION
JavaScript precompliation failed in production with the Rails 7 upgrade. This PR upgrades Uglifier and runs it in harmony mode to [support ES6 syntax](https://stackoverflow.com/questions/56063066/es6-syntax-harmony-mode-must-be-enabled-with-uglifier-newharmony-true).