### PR TITLE
Remove Uglifier

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -42,7 +42,6 @@ gem "simple_form", "~> 5.0.3"
 gem "sinatra", "~> 2.0.8", require: false
 gem "stripe", "~> 1.57.1"
 gem "title"
-gem "uglifier"
 gem "unicorn"
 gem "xmlrpc"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -597,8 +597,6 @@ GEM
     trollop (2.1.2)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
-    uglifier (4.2.1)
-      execjs (>= 0.3.0, < 3)
     unf (0.1.4)
       unf_ext
     unf_ext (0.0.7.6)
@@ -700,7 +698,6 @@ DEPENDENCIES
   stripe-ruby-mock (~> 2.4.0)
   timecop
   title
-  uglifier
   unicorn
   web-console (~> 2.0)
   webmock

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -24,10 +24,6 @@ Rails.application.configure do
   # Disable serving static files from `public/`, relying on NGINX/Apache to do so instead.
   # config.public_file_server.enabled = false
 
-  # Compress JavaScripts and CSS.
-  config.assets.js_compressor = Uglifier.new(harmony: true)
-  # config.assets.css_compressor = :sass
-
   # Do not fall back to assets pipeline if a precompiled asset is missed.
   config.assets.compile = false
 


### PR DESCRIPTION
[Uglifier](https://github.com/lautis/uglifier) compresses our JavaScript, but it's not compatible with ES6, and it blows up when we try to precompile assets for production with Rails 7.1. This PR removes Uglifier and stops trying to compress our (already small) JavaScript. In the future, we could consider the [terser gem](https://github.com/ahorek/terser-ruby) for JavaScript compression.