### PR TITLE
Enable new ActiveSupport::Cache serialization format

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -8,6 +8,8 @@ Bundler.require(*Rails.groups)
 
 module Trailmix
   class Application < Rails::Application
+    config.active_support.cache_format_version = 7.0
+
     config.i18n.enforce_available_locales = true
 
     config.active_record.default_timezone = :utc


### PR DESCRIPTION
Addresses a deprecation warning. See https://guides.rubyonrails.org/upgrading_ruby_on_rails.html#new-activesupport-cache-serialization-format for more details.