### PR TITLE
Use Rails 7.1 framework defaults

### DIFF
--- a/app/assets/stylesheets/base/_header.scss
+++ b/app/assets/stylesheets/base/_header.scss
@@ -21,7 +21,7 @@
   .navbar-right {
     text-align: center;
 
-    li a, li input[type=submit] {
+    li a, li button[type=submit] {
       background: none;
       border: none;
       color: $brown;

--- a/app/models/entry.rb
+++ b/app/models/entry.rb
@@ -1,5 +1,5 @@
 class Entry < ApplicationRecord
-  belongs_to :import
+  belongs_to :import, optional: true
   belongs_to :user
 
   mount_uploader :photo, PhotoUploader

--- a/config/application.rb
+++ b/config/application.rb
@@ -8,7 +8,7 @@ Bundler.require(*Rails.groups)
 
 module Trailmix
   class Application < Rails::Application
-    config.active_support.cache_format_version = 7.0
+    config.load_defaults 7.1
 
     config.i18n.enforce_available_locales = true
 


### PR DESCRIPTION
As part of upgrading to Rails 7, we needed to adopt the [new ActiveSupport::Cache serialization format](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html#new-activesupport-cache-serialization-format). We could do this with an explicit configuration, or by loading the Rails 7 framework defaults. This PR starts using the latest framework defaults.

As part of this, I had to make a couple of changes for framework defaults from previous upgrades. `belongs_to` [now requires `optional: true`](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html#active-record-belongs-to-required-by-default-option) for optional associations, and `button_to` now generates a `<button>` instead of an `<input>`.