### PR TITLE
Upgrade griddler

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -324,7 +324,7 @@ GEM
       i18n
     globalid (1.2.1)
       activesupport (>= 6.1)
-    griddler (1.1.0)
+    griddler (1.6.0)
       htmlentities
       rails (>= 3.2.0)
     griddler-sendgrid (0.0.1)
@@ -368,7 +368,7 @@ GEM
     kgio (2.9.2)
     launchy (2.4.2)
       addressable (~> 2.3)
-    logger (1.6.5)
+    logger (1.6.6)
     loofah (2.24.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
@@ -443,7 +443,7 @@ GEM
     puma (6.4.3)
       nio4r (~> 2.0)
     racc (1.8.1)
-    rack (2.2.10)
+    rack (2.2.11)
     rack-protection (2.0.8.1)
       rack
     rack-session (1.0.2)


### PR DESCRIPTION
With new Rails framework defaults, the current version of griddler raises an `ActionController::InvalidAuthenticityToken` error when replying to a Trailmix email. This was [fixed](https://github.com/thoughtbot/griddler/pull/298) in a more recent version of griddler, so this PR upgrades griddler.