### PR TITLE
Upgrade mini_magick

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -338,9 +338,9 @@ GEM
       domain_name (~> 0.5)
     i18n (1.14.7)
       concurrent-ruby (~> 1.0)
-    image_processing (1.9.1)
-      mini_magick (>= 4.9.3, < 5)
-      ruby-vips (>= 2.0.13, < 3)
+    image_processing (1.14.0)
+      mini_magick (>= 4.9.5, < 6)
+      ruby-vips (>= 2.0.17, < 3)
     inflecto (0.0.2)
     io-console (0.8.0)
     ipaddress (0.8.3)
@@ -384,7 +384,9 @@ GEM
       logger
       mime-types-data (~> 3.2015)
     mime-types-data (3.2025.0204)
-    mini_magick (4.9.4)
+    mini_magick (5.1.2)
+      benchmark
+      logger
     mini_mime (1.1.5)
     mini_portile2 (2.8.8)
     minitest (5.25.4)
@@ -439,7 +441,7 @@ GEM
     psych (5.2.3)
       date
       stringio
-    public_suffix (5.1.1)
+    public_suffix (6.0.1)
     puma (6.4.3)
       nio4r (~> 2.0)
     racc (1.8.1)


### PR DESCRIPTION
The current version of mini_magick raises `TypeError:  no implicit conversion of Hash into Integer` when processing images since upgrading to Ruby 3. This PR upgrades mini_magick to fix image processing.