### PR TITLE
Disable dynamic asset compliation in production

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -22,6 +22,9 @@ Rails.application.configure do
   # Enable serving of images, stylesheets, and JavaScripts from an asset server.
   # config.asset_host = "http://assets.example.com"
 
+  # https://devcenter.heroku.com/articles/rails-4-asset-pipeline#caching
+  config.assets.compile = false
+
   # Store uploaded files on the local file system (see config/storage.yml for options).
   config.active_storage.service = :local
 


### PR DESCRIPTION
Addresses [a warning from Heroku](https://devcenter.heroku.com/articles/rails-4-asset-pipeline#caching) about dynamic asset compilation slowing down Rails apps in production. All of our Rails assets are precompiled.