### PR TITLE
Upgrade to Sidekiq 7

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -31,7 +31,7 @@ gem "rails", "~> 8.0.0"
 gem "recipient_interceptor"
 gem "redis"
 gem "sass-rails", "~> 6.0.0"
-gem "sidekiq", "~> 5.2.10"
+gem "sidekiq", "< 8"
 gem "sprockets", ">= 2.12.5"
 gem "simple_form", "~> 5.0.3"
 gem "sinatra", "~> 2.0.8", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -507,7 +507,10 @@ GEM
       psych (>= 4.0.0)
     recipient_interceptor (0.1.2)
       mail
-    redis (4.5.1)
+    redis (5.3.0)
+      redis-client (>= 0.22.0)
+    redis-client (0.23.2)
+      connection_pool
     regexp_parser (2.9.2)
     reline (0.6.0)
       io-console (~> 0.5)
@@ -559,11 +562,12 @@ GEM
     selenium-webdriver (3.142.7)
       childprocess (>= 0.5, < 4.0)
       rubyzip (>= 1.2.2)
-    sidekiq (5.2.10)
-      connection_pool (~> 2.2, >= 2.2.2)
-      rack (~> 2.0)
-      rack-protection (>= 1.5.0)
-      redis (~> 4.5, < 4.6.0)
+    sidekiq (7.3.9)
+      base64
+      connection_pool (>= 2.3.0)
+      logger
+      rack (>= 2.2.4)
+      redis-client (>= 0.22.2)
     simple_form (5.0.3)
       actionpack (>= 5.0)
       activemodel (>= 5.0)
@@ -689,7 +693,7 @@ DEPENDENCIES
   rspec-rails (~> 6.1.0)
   sass-rails (~> 6.0.0)
   selenium-webdriver
-  sidekiq (~> 5.2.10)
+  sidekiq (< 8)
   simple_form (~> 5.0.3)
   sinatra (~> 2.0.8)
   spring


### PR DESCRIPTION
Dependabot [highlighted](https://github.com/codecation/trailmix/pull/240) a vulnerability with the current version of Sidekiq. This PR upgrades Sidekiq to address that vulnerability. Sidekiq 6 wasn't compatible with our versions of Ruby and Rails, so I upgraded 2 major versions following the [6.0 upgrade](https://github.com/sidekiq/sidekiq/blob/main/docs/6.0-Upgrade.md) and [7.0 upgrade](https://github.com/sidekiq/sidekiq/blob/main/docs/7.0-Upgrade.md) guides.