### PR TITLE
Silence Sidekiq in test output

### DIFF
--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -21,4 +21,5 @@ Sidekiq.configure_client do |config|
       url: ENV["REDIS_URL"],
       ssl_params: { verify_mode: OpenSSL::SSL::VERIFY_NONE }
   }
+  config.logger = Rails.logger if Rails.env.test?
 end


### PR DESCRIPTION
Sidekiq currently inserts a log message into our test output when we run `bundle exec rspec`. This PR follows [this suggestion](https://github.com/sidekiq/sidekiq/issues/5652#issuecomment-1349079163) to silence that.